### PR TITLE
Fix for routes on Heroku

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ WebsiteOne::Application.routes.draw do
   mount Mercury::Engine => '/'
 
   devise_for :users, :controllers => {:registrations => 'registrations', :users => 'index'}
-  # devise does not provide some GET routes, which causes routing exceptions
+  get 'pages/about_us' => 'high_voltage/pages#show', id: 'about_us'
+
   get 'users/sign_out' => redirect('/404.html')
   get 'users/password' => redirect('/404.html')
 


### PR DESCRIPTION
We are getting the following error on Heroku: "Circular dependency detected while autoloading constant UsersController".

This appears only when app is deployed to Heroku

There seems to be a routing problem that could be a result from the static pages we are pointing to. This adds a route to a specific page and I hope it will fix this problem. Not sure about this.
