### PR TITLE
Error output limiting

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,17 +26,17 @@ class ApplicationController < ActionController::Base
 
     def render_error(status, e)
       Rails.logger.error e.message
-      e.backtrace.each { |line| Rails.logger.error line }
+      e.backtrace.each_with_index { |line, index| Rails.logger.error line; break if index > 5 }
       case status
         when 404
           render template: 'pages/not_found', layout: 'layouts/application', status: 404
 
         when 500
-          redirect_to '/internal_server_error'
+          render template: 'pages/internal_error', layout: 'layouts/application', status: 500
 
         else
-          logger.log('Unhandled exception???')
-          redirect_to '/internal_server_error'
+          Rails.logger.error('Unhandled exception')
+          render template: 'pages/internal_error', layout: 'layouts/application', status: 500
       end
     end
 end


### PR DESCRIPTION
PV: **none**
- Limited error logging to make it easier to find errors in the logs
- Render internal server error page instead of redirecting to preserve error URL
