### PR TITLE
Fix for Document version control

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -14,6 +14,14 @@ module DocumentsHelper
     @documents = Document.where("project_id = ?", @project.id).order(:created_at)
   end
 
+  def metadata
+    if @document.versions.empty?
+      "Created #{time_ago_in_words(@document.created_at)} ago by #{@document.user.display_name}"
+    else
+      "#{@document.versions.last.event.titleize}d #{time_ago_in_words(@document.created_at)} ago by #{user_details(@document.versions.last.version_author)}"
+    end
+  end
+
   def created_date
     "Created #{time_ago_in_words(@document.created_at)} ago"
   end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -13,7 +13,7 @@
   <div id="doc-overview">
     <h1><div style="display: inline;" id="document_title" style="width: 100%" data-mercury="simple" data-type="editable"><%= @document.title %></div></h1>
     <div class="doc-status-text">
-      <div><%= "#{@document.versions.last.event.titleize}d #{time_ago_in_words(@document.created_at)} ago" %> by <%=user_details(@document.versions.last.version_author)%></div>
+      <div><%= metadata %></div>
     </div>
   </div>
   <div id="doc-side-panel">

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -171,8 +171,6 @@ Then(/^I should be on the "([^"]*)" page for ([^"]*) "([^"]*)"/) do |action, con
 end
 
 Given(/^I am on the "([^"]*)" page for ([^"]*) "([^"]*)"$/) do |action, controller, title|
-  puts url_for_title(action: action.downcase, controller: controller, title: title)
-
   visit url_for_title(action: action, controller: controller, title: title)
 end
 
@@ -185,7 +183,7 @@ end
 
 Then(/^show me the page$/) do
   save_and_open_page
-  puts page.body
+  #puts page.body
 end
 When(/^I select "([^"]*)" to "([^"]*)"$/) do |field, option|
   find(:select, field).find(:option, option).select_option

--- a/features/step_definitions/documents_steps.rb
+++ b/features/step_definitions/documents_steps.rb
@@ -28,7 +28,7 @@ Given(/^the following revisions exist$/) do |table|
       doc = Document.find_by_title(hash[:title])
       doc.update(:body => "New content #{number}")
       doc.save
-      puts [doc.title, doc.body].join(' ')
+      #puts [doc.title, doc.body].join(' ')
     end
   end
 end

--- a/features/step_definitions/mercury_steps.rb
+++ b/features/step_definitions/mercury_steps.rb
@@ -3,7 +3,7 @@ When /^(?:|I )click "([^"]*)" within Mercury Editor toolbar$/ do |button|
       'save' => 'mercury-save-button'
   }
   page.execute_script("$('.#{selector_for[button.downcase]}').click()")
-  puts 'sleep(0.1)'
+  #puts 'sleep(0.1)'
   sleep(0.1)
 end
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -19,7 +19,6 @@ module Helpers
   end
 
   def create_visitor
-    #@visitor =FactoryGirl(:user)
     @visitor ||= { :email => 'example@example.com',
                    :password => 'changemesomeday',
                    :password_confirmation => 'changemesomeday',
@@ -77,13 +76,6 @@ module Helpers
 
   def all_users
     @all_users = User.all
-    @all_users.each do |user|
-      #user.geocode
-      puts user.email
-      puts user.last_sign_in_ip
-      puts user.longitude
-      puts user.country
-    end
   end
 end
 


### PR DESCRIPTION
- Fallback for metadata display in Documents that have no versions due to being created before version control was implemented.
- Cleaned up som puts in helpers, controllers and in cuke steps
