### PR TITLE
Version Control - Fix for Documents metadata

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -18,7 +18,7 @@ module DocumentsHelper
     if @document.versions.empty?
       "Created #{time_ago_in_words(@document.created_at)} ago by #{@document.user.display_name}"
     else
-      "#{@document.versions.last.event.titleize}d #{time_ago_in_words(@document.created_at)} ago by #{user_details(@document.versions.last.version_author)}"
+      "#{@document.versions.last.event.titleize}d #{time_ago_in_words(@document.versions.last.created_at)} ago by #{user_details(@document.versions.last.version_author)}"
     end
   end
 


### PR DESCRIPTION
#### Version Control - Documents

`time_ago_in_words`was displaying `Document.created_at` rather then `Document.versions.last.created_at`. This is a fix for that.
