### PR TITLE
Bug fix: Display right videos on project show page

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -80,6 +80,7 @@ module Youtube
       project_tags_filter = escape_query_params(project_tags)
 
       request = 'http://gdata.youtube.com/feeds/api/videos?alt=json&max-results=50'
+      request += '&orderby=published'
       request += '&fields=entry(author(name),id,published,title,content,link)'
       #request += '&fields=entry[' + filter.join(' or ') + ']'
 

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -54,7 +54,7 @@ describe 'Youtube helpers' do
   it 'retrieves project videos from youtube filtering by tags and members' do
     project = double(Project, title: 'Big Boom', tag_list: ['Big Regret', 'Boom', 'Bang'])
     members = [double(User, youtube_user_name: 'John Doe'), double(User, youtube_user_name: 'Ivan Petrov')]
-    request_string = %q{http://gdata.youtube.com/feeds/api/videos?alt=json&max-results=50&fields=entry(author(name),id,published,title,content,link)&q=("big+regret"|boom|bang|"big+boom")/("john+doe"|"ivan+petrov")}
+    request_string = %q{http://gdata.youtube.com/feeds/api/videos?alt=json&max-results=50&orderby=published&fields=entry(author(name),id,published,title,content,link)&q=("big+regret"|boom|bang|"big+boom")/("john+doe"|"ivan+petrov")}
 
     expect(Youtube).to receive(:get_response).with(request_string)
     Youtube.project_videos(project, members)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67087358
Added ordering by date to the query, so that the latest videos get included into the list
(at the moment, if there are more than 50 videos for the project, the latest videos might not get included)

deployed to yaro.herokuapp.com
