### PR TITLE
UI fix for Users-show

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,22 +1,20 @@
 <%= javascript_include_tag 'users' %>
 
-<div class="row">
-  <div class="col-md-8 col-md-offset-2 col-sm-5 col-sm-offset-1">
-
+<div class="row" xmlns="http://www.w3.org/1999/html">
+  <div class="col-md-5 col-sm-5">
     <div class="avatar-group">
       <img src="<%= gravatar_for(@user.email, size: 275) %>" class="thumbnail img-rounded media-object">
 
       <div class="avatar-lower">
         <h3><%= @user.display_name %></h3>
-
       </div>
     </div>
     <p><%= "Location: #{@user.country}" if @user.country.present? %></p>
 
     <p>Member for: <%= distance_of_time_in_words(@user.created_at.to_date, Date.current) %> </p>
   </div>
-  <div class="col-md-2 col-sm-5">
-
+  <div class="col-md-7 col-sm-7">
+    <!-- Here is a good place for bio section -->
     <h4>Projects</h4>
     <% unless @users_projects.empty? %>
         <ul>
@@ -25,15 +23,13 @@
           <% end %>
         </ul>
     <% end %>
-
   </div>
 </div>
 <div class="row">
-  <div class="col-md-8 col-md-offset-2 col-sm-5 col-sm-offset-1">
+  <div class="col-md-5 col-sm-5">
     <% if @user.display_email %>
         <h3> <%= @user.email %></h3>
     <% end %>
-
     <%= link_to 'Edit', edit_user_registration_path, class: 'btn btn-primary btn-lg', type: 'button' if @user.eql?(current_user) %>
     <% if @user.eql?(current_user) %>
         <% if @user.youtube_id %>
@@ -42,46 +38,30 @@
             <%= link_to_youtube_button(request.original_url) %>
         <% end %>
     <% end %>
-
     <h4>Pair Programming</h4>
-
     <% unless @youtube_videos.blank? %>
-        <div class="row">
-          <div class="col-md-11">
-            <table class="table table-bordered table-striped table-hover table-condensed" style="margin-left: -15px; width: 100%;">
+        <table class="table table-bordered table-striped table-hover table-condensed">
+          <tr>
+            <th>Title</th>
+          </tr>
+          <% @youtube_videos.each do |video| %>
               <tr>
-                <th>Title</th>
-                <th style="width: 100px;">Published</th>
+                <td><%= video_link(video) %>
+                  <br/>
+                  <small><%= video[:published].to_s(:db) %></small>
+                </td>
               </tr>
-              <% @youtube_videos.each do |video| %>
-                  <tr>
-                    <td><%= video_link(video) %></td>
-                    <td><%= video[:published].to_s(:db) %></td>
-                  </tr>
-              <% end %>
-            </table>
-          </div>
-        </div>
+          <% end %>
+        </table>
     <% else %>
         <h4><%= user_display_name @user %> has no publicly viewable Youtube videos.</h4>
     <% end %>
-
   </div>
   <% unless @youtube_videos.blank? %>
-      <div class="col-md-2 col-sm-5">
-        <table class="table table-condensed">
-          <tr>
-            <td><h4 id="video_contents"><%= @youtube_videos.first[:content] %></h4></td>
-          </tr>
-          <tr>
-            <td>
-              <iframe id="ytplayer" type="text/html" width="640" height="390"
-                      src="<%= video_embed_link(@youtube_videos.first) %>" frameborder="0"/>
-            </td>
-          </tr>
-        </table>
+      <div class="col-md-7 col-sm-7">
+        <td><h4 id="video_contents"><%= @youtube_videos.first[:content] %></h4></td>
+        <iframe id="ytplayer" type="text/html" width="480" height="293" src="<%= video_embed_link(@youtube_videos.first) %>" frameborder="0"></iframe>
       </div>
   <% end %>
 </div>
-
 

--- a/features/users/user_videos.feature
+++ b/features/users/user_videos.feature
@@ -42,7 +42,7 @@ Feature: As a site owner
     And I am on my "profile" page
     When I click "Sync with YouTube"
     Then I should see "Title"
-    And I should see "Published"
+    #And I should see "Published"
     And I should see a list of my videos
     But I should not see "Sync with YouTube"
 


### PR DESCRIPTION
- Refactored the formatting of the user/show page due to bad usage of bootstrap column classes. 
- Fix for footer and supporter banner not showing on users/show page due to lack of closing `<iframe>` tag
- Made changes in UI to make space for all content.
