### PR TITLE
Potential Fix for CSRF exception

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,9 +94,11 @@ module ApplicationHelper
         "/auth/#{provider}#{"?origin=#{CGI.escape(options[:url].gsub(/^[\/]*/, '/'))}" if options[:url].present?}"
 
     raw <<-HTML
+    <div data-no-turbolink>
       <a class="btn btn-lg btn-block btn-social btn-#{provider}" #{'method="delete" ' if options[:delete]}href=#{path}>
         <i class="fa fa-#{fa_icon[provider]}"></i> #{text} #{display_name[provider]}
       </a>
+    </div>
     HTML
   end
 


### PR DESCRIPTION
[Pivotal Tracker](https://www.pivotaltracker.com/story/show/66864310)
- Two lines of code to disable turbolinks for social buttons (it does fix the JavaScript warning with `Access-Control-Allow-Origin` header not set)
