### PR TITLE
Fixed for Sync with Youtube 500 error

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -19,12 +19,12 @@ module UsersHelper
 
   def link_to_youtube_button(origin_url)
     link_to raw('<i class="fa fa-youtube"></i> Sync with YouTube'),
-            "/auth/gplus/?youtube=true&origin=#{origin_url}", class: "btn btn-lg btn-block btn-social btn-danger", type: "button"
+            "/auth/gplus/?youtube=true&origin=#{CGI.escape(origin_url)}", class: "btn btn-lg btn-block btn-social btn-danger", type: "button"
   end
 
   def unlink_from_youtube_button(origin_url)
     link_to raw('<i class="fa fa-youtube"></i> Disconnect YouTube'),
-            "/auth/destroy/youtube?origin=#{origin_url}", class: "btn btn-lg btn-block btn-social btn-danger", type: "button"
+            "/auth/destroy/youtube?origin=#{CGI.escape(origin_url)}", class: "btn btn-lg btn-block btn-social btn-danger", type: "button"
   end
 
   def video_link(video)


### PR DESCRIPTION
Escaped origin param in the Sync with Youtube button to fix 500 internal error
