### PR TITLE
YouTube

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -76,7 +76,7 @@
       <%= social_button provider, url: edit_user_registration_path(resource), delete: resource.has_auth(provider) %>
     <% end %>
     <% if @user.eql?(current_user) %>
-        <div style="margin-top: 10px;" data-no-turbolink>
+        <div style="margin-top: 10px;">
           <% if @user.youtube_id %>
               <%= unlink_from_youtube_button(request.original_url) %>
           <% else %>


### PR DESCRIPTION
[Pivotal Tracker](https://www.pivotaltracker.com/story/show/67620436)
- Removed `data-no-turbolink` from YouTube sync button
