### PR TITLE
Wrapped failing code in begin-rescue

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -10,7 +10,7 @@ module ArticlesHelper
   class CodeRayify < Redcarpet::Render::HTML
     def block_code(code, language)
       begin
-        CodeRay.scan(code, language).div
+        CodeRay.scan(code, language || :plaintext).div
       rescue Exception => e
         Rails.logger.error e
         '<div class="CodeRay"><pre>Failed to render markdown</pre></div>'

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -34,10 +34,10 @@ describe ArticlesHelper do
       output.should be_empty
     end
 
-    it 'should render "Failed to render markdown" when it couldn\'t detect the language' do
+    it 'should render "Failed to render markdown" when it CodeRay fails for whatever reason' do
       renderer = ArticlesHelper::CodeRayify.new
+      CodeRay.stub(:scan).and_raise Exception
       output = renderer.block_code 'function (a, b, c)', nil
-
       output.should have_text 'Failed to render markdown'
     end
 


### PR DESCRIPTION
- Wrapped `CodeRay.scan(...).div` in a begin-rescue statement
- Created Markdown engine on the fly (not sure if this helps...)
