### PR TITLE
click on navbar was giving js error

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
   /* smooth scrolling for nav sections */
   $('#nav .navbar-nav li>a').click(function () {
     var link = $(this).attr('href');
-    var posi = $(link).offset().top + 20;
+    var posi = $('a[href="'+link+'"]').offset().top + 20;
     $('body,html').animate({scrollTop: posi}, 700);
   })
 </script>


### PR DESCRIPTION
js error in console when clicking links like 'Our projects' in the home page navbar.
https://www.pivotaltracker.com/story/show/69418598
Tried switching phantomjs js_errors to be true but no effect. Any other way to test?
