### PR TITLE
updated Google Analytics to work with Turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem 'acts_as_tree'
 gem 'acts_as_follower'
 gem 'will_paginate-bootstrap'
 gem 'coveralls', require: false # TODO Bryan: move to production group?
-gem 'google-analytics-rails'
 gem 'friendly_id'  # for more REST-ful routes, use human-readable IDs
 gem 'colored' # colorizing console
 gem 'redcarpet' # renders markdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,6 @@ GEM
     geocoder (1.2.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    google-analytics-rails (0.0.5)
     hashie (2.1.1)
     hike (1.2.3)
     i18n (0.6.9)
@@ -386,7 +385,6 @@ DEPENDENCIES
   font-awesome-rails
   friendly_id
   geocoder
-  google-analytics-rails
   ice_cube
   jasmine
   jasmine-jquery-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require_directory ./global-modules
 //= require_tree .
 //= stub mercury_init
+//= stub google-analytics
 
 // To deal with the headache of initializing JavaScripts with TurboLinks, I
 // wrote this custom module definer to handle initialization code

--- a/app/assets/javascripts/google-analytics.js
+++ b/app/assets/javascripts/google-analytics.js
@@ -1,0 +1,15 @@
+WebsiteOne.define('GoogleAnalytics', function() {
+  window._gaq = [];
+  window._gaq.push(['_setAccount', 'UA-47795185-1'])
+  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+
+  function init() {
+    window._gaq.push(['_trackPageview']);
+  }
+
+  return {
+    init: init
+  };
+});

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -8,5 +8,7 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
   <link rel="shortcut icon" href="/favicon.ico?v=2" />
-  <%= analytics_init if Rails.env.production? %>
+  <% if ENV['ENABLE_GOOGLE_ANALTICS'] %>
+    <%= javascript_include_tag 'google-analytics', 'data-turbolinks-track' => true %>
+  <% end %>
 </head>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,9 +22,6 @@ WebsiteOne::Application.configure do
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
 
-  GA.tracker = 'UA-47795185-1'
-
-
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,7 +101,6 @@ WebsiteOne::Application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-  GA.tracker = 'UA-47795185-1'
 
   # may be needed for integrating bootstrap with Heroku deployment
   #config.cache_classes = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,6 +32,4 @@ WebsiteOne::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
-
-  GA.tracker = 'UA-00000000-1'
 end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -38,14 +38,6 @@ describe 'layouts/application.html.erb' do
     rendered.should have_xpath("//script[contains(@src, '.js')]")
   end
 
-  it 'should include the Google analytics script' do
-    dummy = Object.new
-    Rails.should_receive(:env).and_return(dummy)
-    dummy.should_receive(:production?).and_return(true)
-    render
-    rendered.should have_xpath("//script[text()[contains(.,#{GA.tracker})]]")
-  end
-
   it 'should not have div nested inside p' do
     should_not have_selector('p>div')
   end


### PR DESCRIPTION
- Updated Google Analytics to work with Turbolinks
- Removed dependency on `google-analytics-rails`
- Add condition to only load google analytics when an environment variable (`ENABLE_GOOGLE_ANALYTICS`) is set
