### PR TITLE
Toggle Travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,3 @@ deploy:
       staging: websiteone-staging
       master: websiteone-production
   run: "rake db:migrate"
-
-notifications:
-  email:
-    # - thomas@nocebo.se
-    # - info@agileventures.org


### PR DESCRIPTION
Switched off Travis custom email notifications, so that:
1. Notifications do not get sent to all the people on the info@agileventures.org mailing list.
2. Notifications do not get sent when developers push to their forked repos.

`By default, a build email is sent to the committer and the author, but only if they have access to the repository the commit was pushed to. This prevents forks active on Travis CI from notifying the upstream repository's owners when they're pushing any upstream changes to their fork. It also prevents build notifications from going to folks not registered on Travis CI.`

More here http://docs.travis-ci.com/user/notifications/#Email-notifications
