### PR TITLE
Fix for Application error on production

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ActiveRecord::Base
   friendly_id :display_name, use: :slugged
 
   validates :email, uniqueness: true
-  after_create :geocode, if: ->(obj){ obj.last_sign_in_ip_changed? }
+  after_validation :geocode, if: ->(obj){ obj.last_sign_in_ip_changed? }
   after_validation ->() { KarmaCalculator.new(self).perform }
 
   has_many :authentications, dependent: :destroy

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,6 +1,5 @@
 Geocoder.configure(
     :lookup => :google,
-    # IP address geocoding service (see below for supported options):
     :ip_lookup => :freegeoip,
     :timeout => 2
 )


### PR DESCRIPTION
PT story https://www.pivotaltracker.com/story/show/72973180

Geocoding method was run on every visit to wso, because Devise's sessions controller updates user model with last_ip and etc. on first :user_signed_in? check.

Added a conditional to run geocoding only if the last_ip has changed.
