### PR TITLE
Improve spec/views/events/show.html.erb_spec.rb

### DIFF
--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -6,7 +6,8 @@ describe 'events/show', type: :view do
     @event = FactoryGirl.build_stubbed(Event, name: 'EuroAsia Scrum',
                         description: 'EuroAsia Scrum and Pair hookup',
                         time_zone: 'Eastern Time (US & Canada)')
-    @event_schedule = @event.next_occurrences
+    allow(Time).to receive(:now).and_return(Time.parse('2014-03-07 23:30:00'))
+    @event_schedule = @event.next_occurrences(end_time: Time.now + 40.days)
   end
 
   it 'should display event information' do


### PR DESCRIPTION
Event factory creates a weekly Sunday event. For `Event#next_occurrences`, default `start_time` is `30.minutes.ago` and `end_time` is `start_time + 10.days`. As a result, the test created one or at most two future occurrences, depending on the day of the week it was run. The proposed changes create 6 events for the test on line 28 (new 29) and make the test run reproducibly.
