### PR TITLE
eliminate unused styles .bg-1 .bg-2 .bg-3 .bg-4 .bg-5

### DIFF
--- a/app/assets/stylesheets/global/custom.css.scss
+++ b/app/assets/stylesheets/global/custom.css.scss
@@ -203,21 +203,6 @@ h1 {
   color: #222;
 }
 
-.bg-4 {
-  padding-top: 30px;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(20, 20, 20, 0.2)), to(rgba(255, 255, 255, 0)), color-stop(1, #000));
-}
-
-.bg-5 {
-  padding-top: 20px;
-  background-color: rgba(255, 255, 255, .9);
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
-  -khtml-border-radius: 5px;
-  border-radius: 5px;
-  padding-bottom: 30px;
-  margin-bottom: 30px;
-}
 
 /* Portfolio css */
 

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -30,35 +30,6 @@ label {
   display: block
 }
 
-
-
-.bg-3 {
-  background: url('bg1-db4d48709782e1e17ea9b9f2c41da4a1.jpg') no-repeat center center fixed;
-  /*background: #f16251; */
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-}
-
-.bg-1 {
-  background: url('http://www.ilikewallpaper.net/ipad-air-wallpapers/download/8253/Dark-Pattern-ipad-4-wallpaper-ilikewallpaper_com_1024.jpg') no-repeat center center fixed;
-  /*background: #f16251;*/
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-}
-
-.bg-2 {
-  background: url(http://mymaplist.com/img/parallax/back.png);
-  background-color: #444;
-  background: url(http://mymaplist.com/img/parallax/pinlayer2.png), url(http://mymaplist.com/img/parallax/pinlayer1.png), url(http://mymaplist.com/img/parallax/back.png);
-  padding-top: 100px;
-  /*background: #ffcc33; */
-
-}
-
 #event-container {
   display: flex;
   flex-flow: row wrap;


### PR DESCRIPTION
We found some unused style classes.

This is how I searched, as well as in rubymine:
`find . -type f | grep -v cache/assets | grep -v ./log  | xargs  grep .bg- --color`

The results include some things like bg-color but I didn't want to complicate the grepping.
https://gist.github.com/apelade/bd5b4393b2b078914221
