### PR TITLE
Refactor static pages controller specs

### DIFF
--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -13,7 +13,7 @@ describe StaticPagesController, :type => :controller do
   let(:valid_session) { {} }
 
   before(:each) do
-    request.env['warden'].stub :authenticate! => user
+    allow(request.env['warden']).to receive(:authenticate!).and_return(user)
     allow(controller).to receive(:current_user) { user }
   end
 


### PR DESCRIPTION
Refactored the expressions so they could fit the recommended rspec3 syntax, as well: 
- added :type => : controller
- build_stubbed the user
- preserved the create statements for the page and child page, because of their relationship and the many methods stubs that had to be done
- added 'expect' in the places where 'should' was used

PT Link: https://www.pivotaltracker.com/story/show/76941170
