### PR TITLE
Remove Scrums Table and Model

### DIFF
--- a/app/models/scrum.rb
+++ b/app/models/scrum.rb
@@ -1,2 +1,0 @@
-class Scrum < ActiveRecord::Base
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,13 +111,6 @@ ActiveRecord::Schema.define(version: 20140725131327) do
   add_index "projects", ["slug"], name: "index_projects_on_slug", unique: true, using: :btree
   add_index "projects", ["user_id"], name: "index_projects_on_user_id", using: :btree
 
-  create_table "scrums", force: true do |t|
-    t.string   "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "youtube_url"
-  end
-
   create_table "static_pages", force: true do |t|
     t.string   "title"
     t.text     "body"


### PR DESCRIPTION
No Pivotal Tracker Story
- Removes Scrums Table from Schema
- Removes Scrum Model as it is not used
