### PR TITLE
Minor changes to development environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ rvm: "2.1.1"
 
 # to enable javascript testing with X server and firefox
 before_install:
-  - "echo 'gem: --no-document' > ~/.gemrc"
   - gem install bundler
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
 
 before_script:
   - bundle exec rake db:create:all
@@ -15,7 +12,7 @@ before_script:
 script:
   - bundle exec rspec --format progress
   - bundle exec rake jasmine:ci
-  - xvfb-run bundle exec cucumber --profile ci
+  - bundle exec cucumber --profile ci
 
 # downgrade git version to avoid deployment bug (keep till its fixed)
 before_install:

--- a/Guardfile
+++ b/Guardfile
@@ -36,7 +36,7 @@ guard 'rspec', cmd: 'rspec', bundler: false, all_after_pass: false do
 end
 
 # guard 'cucumber', all_on_start: false, all_after_pass: false, command_prefix: 'zeus', bundler: false, cli: '--tags ~@ignore --no-profile --color --format pretty --strict' do
-guard 'cucumber', all_on_start: false, all_after_pass: false, bundler: false, cli: '--tags ~@ignore --no-profile --color --format pretty --strict' do
+guard 'cucumber', all_on_start: false, all_after_pass: false, bundler: false, focus_on: '@wip', cli: '--tags ~@ignore --no-profile --color --format pretty --strict' do
   watch(%r{^features/.+\.feature$})
   watch(%r{^features/support/.+$})          { 'features' }
   watch(%r{^features/step_definitions/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'features' }


### PR DESCRIPTION
- add @wip tag to Guard config.  Marking a cucumber scenarios with this tag would cause Guard to run only them.
- removed xvfb from travis config, since we are now using phantomjs
