### PR TITLE
Orphan documents

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,6 @@
 class Article < ActiveRecord::Base
   include ActAsPage
+  include UserNullable
 
   belongs_to :user
   validates :content, :user, presence: true

--- a/app/models/concerns/user_nullable.rb
+++ b/app/models/concerns/user_nullable.rb
@@ -1,0 +1,5 @@
+module UserNullable 
+  def user 
+    super || NullUser.new('Anonymous')
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,6 @@
 class Document < ActiveRecord::Base
   include ActAsPage
+  include UserNullable
 
   belongs_to :project
   belongs_to :user

--- a/app/models/hangout.rb
+++ b/app/models/hangout.rb
@@ -1,6 +1,7 @@
 class Hangout < ActiveRecord::Base
   belongs_to :event
   belongs_to :user
+  include UserNullable
   belongs_to :project
 
   serialize :participants

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -1,11 +1,11 @@
 class NullUser < User
 
-  def initialize(name)
-    super({ first_name: name, created_at: Time.now })
+  def persisted?
+    false 
   end
 
-  def save
-    raise 'The UserNull instance should not be persisted'
+  def initialize(name)
+    super({ first_name: name, created_at: Time.now })
   end
 
   def presenter

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,7 @@ class Project < ActiveRecord::Base
   validates :github_url, uri: true, :allow_blank => true
 
   belongs_to :user
+  include UserNullable
   has_many :documents
   has_many :hangouts
   has_many :commit_counts

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,6 +119,8 @@ ActiveRecord::Schema.define(version: 20140730123120) do
     t.datetime "updated_at"
     t.integer  "user_id"
     t.string   "slug"
+    t.string   "github_owner"
+    t.string   "github_repo"
     t.string   "github_url"
     t.string   "pivotaltracker_url"
   end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -2,8 +2,8 @@ Given /^I have an avatar image at "([^"]*)"$/ do |link|
   @avatar_link = link
 end
 
-Given /^I am logged in as user with email "([^"]*)", with password "([^"]*)"$/ do |email, password|
-  @user = FactoryGirl.create(:user, email: email, password: password, password_confirmation: password)
+Given /^I am logged in as user with (?:name "([^"]*)", )?email "([^"]*)", with password "([^"]*)"$/ do |name, email, password|
+  @user = FactoryGirl.create(:user, first_name: name, email: email, password: password, password_confirmation: password)
   visit new_user_session_path
   within ('#main') do
     fill_in 'user_email', :with => email
@@ -378,4 +378,8 @@ end
 
 Given(/^I fetch the GitHub contribution statistics$/) do
   GithubCommitsJob.run
+end
+
+When(/^I delete my profile$/) do 
+  @user.delete
 end

--- a/features/users/user_management.feature
+++ b/features/users/user_management.feature
@@ -4,9 +4,8 @@ Feature: Create and maintain projects
   And I would like to be able to edit change my credentials
 
   Background:
-    Given I am logged in as user with email "current@email.com", with password "12345678"
+    Given I am logged in as user with name "Bob", email "current@email.com", with password "12345678"
     And I am on the "home" page
-
 
   Scenario: Having My account page
     Given I am on my "Edit Profile" page
@@ -57,3 +56,14 @@ Feature: Create and maintain projects
     And my profile should be updated with my GH username
     When I am on "profile" page for user "me"
     Then I should see a link "tochman" to "https://github.com/tochman"
+
+  Scenario: Deleting my profile
+    Given the following projects exist:
+      | title       | description          | status   | author |
+      | hello world | greetings earthlings | active   | Bob    |
+    And the following documents exist:
+      | title         | body             | project     |
+      | Documentation | My documentation | hello world |
+    When I delete my profile
+    And I am on the "Show" page for project "hello world"
+    Then I should see "by Anonymous"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Article, :type => :model do
 
-  subject { Article.new slug: 'test-article' }
+  let(:user) { FactoryGirl.create :user } 
+  subject { Article.new slug: 'test-article', user: user }
 
   it { is_expected.to respond_to :tag_list}
   it { is_expected.to respond_to :user}

--- a/spec/models/hangout_spec.rb
+++ b/spec/models/hangout_spec.rb
@@ -21,7 +21,7 @@ describe Hangout, type: :model do
     before { hangout.hangout_url = 'test' }
 
     it 'reports live if the link is not older than 5 minutes' do
-      allow(Time).to receive(:now).and_return(Time.parse('10:04:59 UTC'))
+      allow(Time).to receive(:now).and_return(Time.mktime('10:04:59'))
       expect(hangout.live?).to be_truthy
     end
 


### PR DESCRIPTION
Deleting a user who is the owner of documents causes 500 internal server error on project pages, could be the same for tags.
- Add a new `UserNullable` concern to be include in any association between and user and that particular entity; the concern will return a `NullUser` if a nil one is set.

https://www.pivotaltracker.com/n/projects/982890/stories/66066822
