### PR TITLE
Live sessions: fixing coffee -> js conversion bug

### DIFF
--- a/app/assets/javascripts/hangouts.js
+++ b/app/assets/javascripts/hangouts.js
@@ -33,27 +33,29 @@ this.HangoutsUtils = function() {
     });
   };
 
-  this.updateHangoutsData = function(data) {
-    var _this = this;
-    data = data.trim();
+  this.updateHangoutsData = (function(_this) {
+    return function(data) {
+      data = data.trim();
 
-    if (data !== _this.container) {
-      if (_this.container) {
-        $('#hg-container').html(data);
-        _this.bindEvents();
+      if (data !== _this.container) {
+        if (_this.container) {
+          $('#hg-container').html(data);
+          _this.bindEvents();
+        }
+        _this.container = data;
       }
-      _this.container = data;
-    }
-  };
+    };
+  })(this);
 
-  this.ajaxRequest = function() {
-    var _this = this;
-    if (window.location.href === _this.href) {
-      $.get(_this.href, _this.updateHangoutsData);
-    } else {
-      clearInterval(_this.intervalId);
-    }
-  };
+  this.ajaxRequest = (function(_this) {
+    return function() {
+      if (window.location.href === _this.href) {
+        $.get(_this.href, _this.updateHangoutsData);
+      } else {
+        clearInterval(_this.intervalId);
+      }
+    };
+  })(this);
 };
 
 (new this.HangoutsUtils).init();

--- a/spec/javascripts/hangouts_spec.js
+++ b/spec/javascripts/hangouts_spec.js
@@ -21,6 +21,7 @@ describe('RefreshHangouts', function() {
 
   it('does not replace hg-management section if data has not updated', function() {
     spyOn(this.app, 'bindEvents');
+    this.app.container = 'new data';
     this.app.updateHangoutsData('new data');
     expect($('#hg-container').text()).toEqual('');
   });


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/74032372

fixing scoping _this bug introduced when manually converting from coffee to js, which stopped live sessions from refreshing.
