### PR TITLE
Fix for Cucumber Bug in Github Commit Count

### DIFF
--- a/features/users/github_commit_count.feature
+++ b/features/users/github_commit_count.feature
@@ -1,3 +1,4 @@
+@github_query
 Feature: Displaying GitHub contribution statistics for user
   As a member of AV
   So that I can find out what projects others are contributing to


### PR DESCRIPTION
The cucumber feature was failing as I forgot to mark the scenarios with the vcr hook and it was live data every time. 

When Bryan submitted his PR, his commit count increased and it failed.

I've added the hook and it should pass right now.
