### PR TITLE
Responsive  class for YT videos

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -22,3 +22,19 @@
 .custom_menu_link {
   color: white !important;
 }
+
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px; height: 0; overflow: hidden;
+}
+
+.video-container iframe,
+.video-container object,
+.video-container embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100% !important;
+  height: 100% !important;
+}

--- a/app/views/projects/_videos_list.html.erb
+++ b/app/views/projects/_videos_list.html.erb
@@ -1,7 +1,10 @@
 <% unless @videos.empty? %>
     <div class="col-sm-12">
       <h4 id="video_contents"><%= @videos.first[:content] %></h4>
-      <iframe id="ytplayer" type="text/html" width="480" height="320" src="<%= video_embed_link(@videos.first) %>" frameborder="0"></iframe>
+
+      <div class="video-container">
+        <iframe id="ytplayer" type="text/html" width="480" height="320" src="<%= video_embed_link(@videos.first) %>" frameborder="0"></iframe>
+      </div>
     </div>
     <div class="col-sm-12">
       <h2>List of Project videos</h2>
@@ -19,7 +22,7 @@
             </tr>
         <% end %>
       </table>
-      </div>
+    </div>
 <% else %>
     <p>No videos in project <strong><%= @project.title %></strong></p>
 <% end %>

--- a/app/views/scrums/index.html.erb
+++ b/app/views/scrums/index.html.erb
@@ -2,7 +2,9 @@
 <div class="row">
   <div class="col-xs-12 col-sm-10">
     <h1>Previous scrums</h1>
-    <p>We have regular daily meetings (scrums) online where our members get together, discuss projects, share knowledge and plan programming sessions. </p>
+
+    <p>We have regular daily meetings (scrums) online where our members get together, discuss projects, share knowledge
+      and plan programming sessions. </p>
   </div>
 </div>
 <!-- Modal -->
@@ -14,7 +16,9 @@
         <h4 class="modal-title" id="playerTitle"></h4>
       </div>
       <div class="modal-body">
-        <iframe width="560" height="315" src="" frameborder="0" allowfullscreen></iframe>
+        <div class="video-container">
+          <iframe width="560" height="315" src="" frameborder="0" allowfullscreen="true"></iframe>
+        </div>
       </div>
     </div>
   </div>
@@ -22,23 +26,27 @@
 
 <ul class="timeline">
   <% @scrums.each_slice(2) do |videos| %>
-        <li class="arrow-left">
-          <div class="timeline-badge"><i class="fa fa-film"></i></div>
-          <div class="timeline-panel" >
-            <div class="timeline-heading">
-                <%= scrum_link videos.first %>
-                <p><small><i class="fa fa-clock-o">&nbsp</i><%= videos.first[:published].to_date %></small></p>
-            </div>
+      <li class="arrow-left">
+        <div class="timeline-badge"><i class="fa fa-film"></i></div>
+        <div class="timeline-panel">
+          <div class="timeline-heading">
+            <%= scrum_link videos.first %>
+            <p>
+              <small><i class="fa fa-clock-o">&nbsp</i><%= videos.first[:published].to_date %></small>
+            </p>
           </div>
-        </li>
-        <li class="timeline-inverted arrow-right">
-          <div class="timeline-badge warning"><i class="fa fa-film"></i></div>
-          <div class="timeline-panel" >
-            <div class="timeline-heading">
-                <%= scrum_link videos.last %>
-                <p><small><i class="fa fa-clock-o"></i><%= videos.last[:published].to_s(:db) %></small></p>
-            </div>
+        </div>
+      </li>
+      <li class="timeline-inverted arrow-right">
+        <div class="timeline-badge warning"><i class="fa fa-film"></i></div>
+        <div class="timeline-panel">
+          <div class="timeline-heading">
+            <%= scrum_link videos.last %>
+            <p>
+              <small><i class="fa fa-clock-o"></i><%= videos.last[:published].to_s(:db) %></small>
+            </p>
           </div>
-        </li>
+        </div>
+      </li>
   <% end %>
-  </ul>
+</ul>

--- a/app/views/users/profile/_videos.html.erb
+++ b/app/views/users/profile/_videos.html.erb
@@ -1,28 +1,31 @@
 <% unless videos.blank? %>
-  <div class="row">
-    <h4 id="video_contents"><%= videos.first[:content] %></h4>
-    <div class="col-xs-12 text-center">
-      <iframe id="ytplayer" width="480" height="320" type="text/html" src="<%= video_embed_link(videos.first) %>" frameborder="0"></iframe>
+    <div class="row">
+      <h4 id="video_contents"><%= videos.first[:content] %></h4>
+
+      <div class="col-xs-12 text-center">
+        <div class="video-container">
+          <iframe id="ytplayer" width="480" height="320" type="text/html" src="<%= video_embed_link(videos.first) %>" frameborder="0"></iframe>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <h4>Latest pairing videos by <%= presenter.display_name %></h4>
-    <table class="table table-bordered table-striped table-hover table-condensed">
-      <tr>
-        <th>Title</th>
-      </tr>
-      <% videos.each do |video| %>
+    <div class="row">
+      <h4>Latest pairing videos by <%= presenter.display_name %></h4>
+      <table class="table table-bordered table-striped table-hover table-condensed">
         <tr>
-          <td><%= video_link(video) %>
-            <br/>
-            <small><%= video[:published].to_s(:db) %></small>
-          </td>
+          <th>Title</th>
         </tr>
-      <% end %>
-    </table>
-  </div>
+        <% videos.each do |video| %>
+            <tr>
+              <td><%= video_link(video) %>
+                <br/>
+                <small><%= video[:published].to_s(:db) %></small>
+              </td>
+            </tr>
+        <% end %>
+      </table>
+    </div>
 <% else %>
-  <div class="col-sm-12">
-    <p><%= presenter.display_name %> has no publicly viewable Youtube videos.</p>
-  </div>
+    <div class="col-sm-12">
+      <p><%= presenter.display_name %> has no publicly viewable Youtube videos.</p>
+    </div>
 <% end %>

--- a/vendor/assets/javascripts/mercury_overrides.js
+++ b/vendor/assets/javascripts/mercury_overrides.js
@@ -150,9 +150,12 @@ this.Mercury.modalHandlers.insertMedia = {
                     frameborder: 0,
                     allowfullscreen: 'true'
                 });
+
+                wrapper = jQuery('<div>', { class: 'video-container' });
+                value.appendTo(wrapper);
                 return Mercury.trigger('action', {
                     action: 'insertHTML',
-                    value: value
+                    value: wrapper
                 });
             case 'vimeo_url':
                 url = this.element.find('#media_vimeo_url').val();


### PR DESCRIPTION
PT Chore https://www.pivotaltracker.com/story/show/79654966
- added `video-container` css class 
- wrapped yt players with a div with  `video-container` on:
  - scrums timeline
  - user/show
  - project/show `_video_list.html.erb` 
- Added a wrapper to mercury editor to be added to `<iframe>` when inserting yt file

Demo: http://wso-events.herokuapp.com/
