### PR TITLE
TZ mismatch in event_spec.rb

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Event, :type => :model do
+  before(:each) do
+    ENV['TZ'] = 'UTC'
+  end
+
   subject { build_stubbed :event }
 
   it { is_expected.to respond_to :friendly_id }


### PR DESCRIPTION
PT bug: https://www.pivotaltracker.com/story/show/79730488
- added a before block with `ENV['TZ'] = 'UTC'` 
