### PR TITLE
Github Commit Count Bugfix

### DIFF
--- a/app/jobs/github_commits_job.rb
+++ b/app/jobs/github_commits_job.rb
@@ -21,6 +21,7 @@ module GithubCommitsJob
     loop do
       contributors = Octokit.contributor_stats(repo)
       return contributors unless contributors.nil?
+      Rails.logger.warn "Waiting for Github to calculate project statistics for #{repo}"
       sleep 3
     end
   end


### PR DESCRIPTION
Pivotal Tracker Story: https://www.pivotaltracker.com/story/show/78678240

According to the Github API docs on Contributor Statistics (https://developer.github.com/v3/repos/statistics/#contributors)

> Computing repository statistics is an expensive operation, so we try to return cached data whenever possible. If the data hasn’t been cached when you query a repository’s statistics, you’ll receive a 202 response; a background job is also fired to start compiling these statistics. Give the job a few moments to complete, and then submit the request again. If the job has completed, that request will receive a 200 response with the statistics in the response body.

When this happens, the octokit gem returns nil, which causes our code to fail.

I've added a loop to make sure that the code waits until the latest contributor data has been computed by github.
