### PR TITLE
[#78406180] Change "in 0 minutes" to "about to start..." on the landing page.

### DIFF
--- a/app/views/layouts/_event_link.html.erb
+++ b/app/views/layouts/_event_link.html.erb
@@ -1,11 +1,14 @@
 <% if event.present? %>
   <p>
     <%= link_to event['name'], event_path(event['id']) %>
-    <% if event.next_occurrence_time_attr.to_datetime < Time.now %>
+    <% start_time = event.next_occurrence_time_attr.to_datetime %>
+    <% if start_time < Time.now %>
       is live!
       <% if event.last_hangout.try!(:live?) %>
         <%= link_to 'Click to join!', event.last_hangout.hangout_url %>
       <% end  %>
+    <% elsif start_time - 1.minute < Time.now %>
+      about to start...
     <% else %>
       in <%= display_countdown(event) %>
   <% end %>

--- a/spec/views/visitors/index.html.erb_spec.rb
+++ b/spec/views/visitors/index.html.erb_spec.rb
@@ -91,6 +91,18 @@ describe 'visitors/index.html.erb', type: :view do
     end
   end
 
+  context 'event will start less than 1 minute' do
+    before :each do
+      fix_time_at('2014-03-07 10:29:01 UTC')
+    end
+
+    it 'should <event> about to start' do
+      render
+      expect(rendered).to have_link @event.name, event_path(@event)
+      expect(rendered).to have_text 'about to start...'
+    end
+  end
+
   context 'event has started less than 15 minutes ago' do
     before :each do
       fix_time_at('2014-03-07 10:44:00 UTC')


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/982890/stories/78406180

Change "in 0 minutes" to "about to start..." on the landing page as @tochman asked, but not 5 minutes just in 1 minutes shows this text. I guess this is better.
