### PR TITLE
Tweet YT recordings

### DIFF
--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -51,10 +51,13 @@ class EventInstance < ActiveRecord::Base
   def tweet_yt_link
     case self.category
       when 'Scrum'
-        TwitterService.tweet("Did you miss our #scrum? You can catch the recording at youtu.be/#{self.yt_video_id} #opensource #distributedteam")
+        TwitterService.tweet("#{broadcaster} just hosted an online #scrum using ##googlehangouts Missed it? Catch the recording at youtu.be/#{event.yt_video_id} #opensource")
       when 'PairProgramming'
-        broadcaster = self.participants.each { |_, hash| break hash['person']['displayName'] if hash['isBroadcaster'] == 'true' }
         TwitterService.tweet("#{broadcaster} just finished #PairProgramming on #{self.project.title} You can catch the recording at youtu.be/#{self.yt_video_id} #opensource #pairwithme")
     end
+  end
+
+  def broadcaster
+    self.participants.each { |_, hash| break hash['person']['displayName'] if hash['isBroadcaster'] == 'true' }
   end
 end

--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -51,7 +51,7 @@ class EventInstance < ActiveRecord::Base
   def tweet_yt_link
     case self.category
       when 'Scrum'
-        TwitterService.tweet("#{broadcaster} just hosted an online #scrum using ##googlehangouts Missed it? Catch the recording at youtu.be/#{event.yt_video_id} #opensource")
+        TwitterService.tweet("#{broadcaster} just hosted an online #scrum using ##googlehangouts Missed it? Catch the recording at youtu.be/#{self.yt_video_id} #opensource")
       when 'PairProgramming'
         TwitterService.tweet("#{broadcaster} just finished #PairProgramming on #{self.project.title} You can catch the recording at youtu.be/#{self.yt_video_id} #opensource #pairwithme")
     end

--- a/features/hangout.feature
+++ b/features/hangout.feature
@@ -30,17 +30,17 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
   Scenario: Show hangout details
     Given the Hangout for event "Scrum" has been started with details:
       | EventInstance link | http://hangout.test |
-      | Started at   | 10:25:00            |
+      | Started at         | 10:25:00            |
     And the time now is "10:29:00 UTC"
     When I am on the show page for event "Scrum"
     Then I should see Hangouts details section
     And I should see:
-        | Category            |
-        | Scrum               |
-        | Title               |
-        | Daily scrum meeting |
-        | Updated             |
-        | 4 minutes ago       |
+      | Category            |
+      | Scrum               |
+      | Title               |
+      | Daily scrum meeting |
+      | Updated             |
+      | 4 minutes ago       |
     And I should see link "http://hangout.test" with "http://hangout.test"
 
   @javascript
@@ -66,14 +66,14 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
     Then the hangout button should not be visible
 
   @javascript
-   Scenario: Edit URL
-     Given I am on the show page for event "Scrum"
-     When I click the link "Edit hangout link"
-     Then I should see button "Cancel"
+  Scenario: Edit URL
+    Given I am on the show page for event "Scrum"
+    When I click the link "Edit hangout link"
+    Then I should see button "Cancel"
 
-     When I fill in "hangout_url" with "http://test.com"
-     And I click the "Save" button
-     Then I should see link "http://test.com" with "http://test.com"
+    When I fill in "hangout_url" with "http://test.com"
+    And I click the "Save" button
+    Then I should see link "http://test.com" with "http://test.com"
 
   @javascript
   Scenario: Cancel Edit URL
@@ -87,7 +87,7 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
     Given the date is "2014/02/03 07:04:00 UTC"
     And the Hangout for event "Scrum" has been started with details:
       | EventInstance link | http://hangout.test |
-      | Started at   | 07:00:00            |
+      | Started at         | 07:00:00            |
 
     When I am on the show page for event "Scrum"
     Then I should see link "EVENT IS LIVE" with "http://hangout.test"
@@ -105,32 +105,31 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
   Scenario: Display live sessions - basic info
     Given the date is "2014/02/01 11:10:00 UTC"
     And the following hangouts exist:
-      | Start time | Title        | Project     | Event         | Category        | Host  | EventInstance url            | Youtube video id | End time |
-      | 11:15      | HangoutsFlow | WebsiteOne  | Scrum         | PairProgramming | Alice | http://hangout.test    | QWERT55          | 11:25    |
-      | 11:11      | GithubClone  | Autograders | Retrospective | ClientMeeting   | Bob   | http://hangout.session | TGI345           | 12:42    |
-
+      | Start time | Title        | Project     | Event         | Category        | Host  | EventInstance url      | Youtube video id | End time |Participants|
+      | 11:15      | HangoutsFlow | WebsiteOne  | Scrum         | PairProgramming | Alice | http://hangout.test    | QWERT55          | 11:25    |Alice, Bob  |
+      | 11:11      | GithubClone  | Autograders | Retrospective | ClientMeeting   | Bob   | http://hangout.session | TGI345           | 12:42    |Alice, Bob  |
     When I visit "/hangouts"
     Then I should see:
-        | Started at   |
-        | Title        |
-        | Project      |
-        | Host         |
-        | Join         |
-        | Watch        |
+
+      | Title      |
+      | Project    |
+      | Host       |
+      | Join       |
+      | Watch      |
     And I should see:
-        | 11:15           |
-        | 01/02           |
-        | HangoutsFlow    |
-        | WebsiteOne      |
+      | 11:15        |
+      | 01/02        |
+      | HangoutsFlow |
+      | WebsiteOne   |
     And I should see the avatar for "Alice"
     And I should see link "Join" with "http://hangout.test"
     And I should see link "Watch" with "http://www.youtube.com/watch?v=QWERT55&feature=youtube_gdata"
 
     And I should see:
-        | 11:11         |
-        | 01/02         |
-        | GithubClone   |
-        | Autograders   |
+      | 11:11       |
+      | 01/02       |
+      | GithubClone |
+      | Autograders |
     And I should see the avatar for "Bob"
     And I should see link "Join" with "http://hangout.session"
     And I should see link "Watch" with "http://www.youtube.com/watch?v=TGI345&feature=youtube_gdata"
@@ -144,18 +143,18 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
 
     When I visit "/hangouts"
     Then I should see:
-        | Event        |
-        | Category     |
-        | Participants |
-        | Duration     |
+      | Event        |
+      | Category     |
+      | Participants |
+      | Duration     |
     Then I should see:
-        | Scrum           |
-        | PairProgramming |
-        | 10 min          |
+      | Scrum           |
+      | PairProgramming |
+      | 10 min          |
     And I should see the avatar for "Jane"
     And I should see the avatar for "Bob"
 
     And I should see:
-        | Retrospective |
-        | ClientMeeting |
-        | about 2 hours |
+      | Retrospective |
+      | ClientMeeting |
+      | about 2 hours |

--- a/spec/factories/event_instances.rb
+++ b/spec/factories/event_instances.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   sequence :participant do |n|
-    [ "#{n}", { :person => { displayName: "Participant_#{n}", id: "youtube_id_#{n}" } } ]
+    [ "#{n}", { :person => { displayName: "Participant_#{n}", id: "youtube_id_#{n}", isBroadcaster: 'false' } } ]
+  end
+  sequence :broadcaster do |n|
+    [ "#{n}", { :person => { displayName: "Broadcaster#{n}", id: "youtube_id_#{n}", isBroadcaster: 'true' } } ]
   end
 
   factory :event_instance do
@@ -19,7 +22,7 @@ FactoryGirl.define do
     event
     user
 
-    participants { [(generate :participant), (generate :participant)] }
+    participants { [(generate :broadcaster), (generate :participant)] }
 
     created_at { Time.parse("#{created} UTC")}
     updated_at { Time.parse("#{updated} UTC")}

--- a/spec/models/event_instance_spec.rb
+++ b/spec/models/event_instance_spec.rb
@@ -71,7 +71,7 @@ describe EventInstance, type: :model do
                                 "2" => {"id" => "xxx.id.google.com^xxx", "hasMicrophone" => "true",
                                         "hasCamera" => "true", "hasAppEnabled" => "true",
                                         "isBroadcaster" => "true", "isInBroadcast" => "true",
-                                        "displayIndex" => "2", "person" => 
+                                        "displayIndex" => "2", "person" =>
                                             {"id" => "xxx", "displayName" => "John Doe",
                                              "image" => {"url" => ".../s96-c/photo.jpg"}, "fa" => "false"},
                                         "locale" => "en", "fa" => "false"}}

--- a/spec/models/event_instance_spec.rb
+++ b/spec/models/event_instance_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe EventInstance, type: :model do
-  let(:hangout){ FactoryGirl.create(:event_instance, updated: '10:00 UTC', hangout_url: nil) }
+  let(:hangout) { FactoryGirl.create(:event_instance, updated: '10:00 UTC', hangout_url: nil) }
 
   context 'hangout_url is not present' do
     before do
@@ -36,6 +36,61 @@ describe EventInstance, type: :model do
     end
   end
 
+  context 'yt_video_id is present' do
+    before { hangout.yt_video_id = 'YT123456' }
+
+    it 'calls tweet_yt_link' do
+      expect(hangout).to receive(:tweet_yt_link)
+      hangout.save
+    end
+
+    it 'calls the TwitterService' do
+      hangout.category = 'Scrum'
+
+      expect(TwitterService).to receive(:tweet)
+      hangout.save
+    end
+
+    context 'pair programming tweet' do
+      before(:each) do
+        hangout.category = 'PairProgramming'
+        hangout.participants = {"0" => {"id" => "xxx.id.google.com^xxx", "hasMicrophone" => "true",
+                                        "hasCamera" => "true", "hasAppEnabled" => "false",
+                                        'isBroadcaster' => "false", "isInBroadcast" => "true",
+                                        "displayIndex" => "0", "person" =>
+                                            {"id" => "xxx", "displayName" => "Foo Bar",
+                                             "image" => {"url" => ".../s96-c/photo.jpg"},
+                                             "fa" => "false"}, "locale" => "en", "fa" => "false"},
+                                "1" => {"id" => "xxx.id.google.com^xxx", "hasMicrophone" => "true",
+                                        "hasCamera" => "true", "hasAppEnabled" => "false",
+                                        "isBroadcaster" => "false", "isInBroadcast" => "true",
+                                        "displayIndex" => "1", "person" =>
+                                            {"id" => "xxx", "displayName" => "Bar Foo",
+                                             "image" => {"url" => ".../s96-c/photo.jpg"},
+                                             "fa" => "false"}, "locale" => "en", "fa" => "false"},
+                                "2" => {"id" => "xxx.id.google.com^xxx", "hasMicrophone" => "true",
+                                        "hasCamera" => "true", "hasAppEnabled" => "true",
+                                        "isBroadcaster" => "true", "isInBroadcast" => "true",
+                                        "displayIndex" => "2", "person" => 
+                                            {"id" => "xxx", "displayName" => "John Doe",
+                                             "image" => {"url" => ".../s96-c/photo.jpg"}, "fa" => "false"},
+                                        "locale" => "en", "fa" => "false"}}
+        @broadcaster = hangout.participants.each { |_, hash| break hash['person']['displayName'] if hash['isBroadcaster'] == 'true' }
+      end
+      it 'includes hosts name ' do
+        expect(@broadcaster).to eq 'John Doe'
+        expect(TwitterService).to receive(:tweet).with(/#{@broadcaster}/) { :success }
+        hangout.save
+      end
+
+      it 'includes Project title' do
+        expect(TwitterService).to receive(:tweet).with(/#{hangout.project.title}/) { :success }
+        hangout.save
+      end
+    end
+
+  end
+
   context 'event category is recognized' do
     before do
       hangout.hangout_url = 'test'
@@ -51,7 +106,7 @@ describe EventInstance, type: :model do
     it 'project title is included in a pair programming tweet' do
       hangout.category = 'PairProgramming'
 
-      expect(TwitterService).to receive(:tweet).with(/#{hangout.project.title}/ ) {:success}
+      expect(TwitterService).to receive(:tweet).with(/#{hangout.project.title}/) { :success }
       hangout.save
     end
   end
@@ -78,7 +133,7 @@ describe EventInstance, type: :model do
 
   context 'event_instance is changed' do
     before do
-      @hangout_with_url = FactoryGirl.create(:event_instance, 
+      @hangout_with_url = FactoryGirl.create(:event_instance,
                                              hangout_url: 'http://example.com')
     end
 

--- a/spec/models/event_instance_spec.rb
+++ b/spec/models/event_instance_spec.rb
@@ -91,6 +91,15 @@ describe EventInstance, type: :model do
 
   end
 
+  context 'yt_video_id is NOT present' do
+    before { hangout.yt_video_id = nil }
+
+    it 'does not call TwitterService' do
+      expect(TwitterService).to_not receive(:tweet)
+      hangout.save
+    end
+  end
+
   context 'event category is recognized' do
     before do
       hangout.hangout_url = 'test'


### PR DESCRIPTION
PT story (addition to previous https://github.com/AgileVentures/WebsiteOne/pull/613 and https://github.com/AgileVentures/WebsiteOne/pull/592) https://www.pivotaltracker.com/story/show/65542324

- Triggers a tweet (TwitterService) with link to recording when `yt_video_id` is present on an EventInstance.
- One version for 'Scrum' and one version for 'PairProgramming' categories