### PR TITLE
Statistics - calculate_duration

### DIFF
--- a/app/controllers/concerns/statistics.rb
+++ b/app/controllers/concerns/statistics.rb
@@ -21,6 +21,6 @@ module Statistics
   end
 
   def calculate_duration(category)
-    EventInstance.where(category: category).map(&:duration).sum
+    EventInstance.where(category: category).map(&:duration).sum.to_i/60
   end
 end


### PR DESCRIPTION
- refactored 'calculate_duration' to display duration as integer and as minutes rather than seconds.