### PR TITLE
PATCH: Fix revisions toggle link on about page

### DIFF
--- a/app/assets/javascripts/documents.js
+++ b/app/assets/javascripts/documents.js
@@ -1,16 +1,8 @@
-WebsiteOne.define('Documents', function(){
-  function init(){
-    //alert('this shit is on');
-    $('#revisions-anchor').on('click', function(e){
-      e.preventDefault();
-      //$('#revisions').css('display', 'block');
-      $('#revisions').slideToggle('slow');
-      $("#arrow").toggleClass("fa-arrow-up").toggleClass("fa-arrow-down");
-      //alert('ooh, it\'s ooon!');
-    });
-  }
-
-  return {
-    init: init
-  }
+$(document).ready(function() {
+  $('#revisions-anchor').on('click', function(e){
+    e.preventDefault();
+    $('#revisions').slideToggle('slow');
+    $("#arrow").toggleClass("fa-arrow-up").toggleClass("fa-arrow-down");
+  });
+  return false;
 });

--- a/app/assets/javascripts/documents.js
+++ b/app/assets/javascripts/documents.js
@@ -1,8 +1,13 @@
-$(document).ready(function() {
-  $('#revisions-anchor').on('click', function(e){
-    e.preventDefault();
-    $('#revisions').slideToggle('slow');
-    $("#arrow").toggleClass("fa-arrow-up").toggleClass("fa-arrow-down");
-  });
-  return false;
+WebsiteOne.define('Documents', function(){
+  function init(){
+    $('#revisions-anchor').on('click', function(e){
+      e.preventDefault();
+      $('#revisions').slideToggle('slow');
+      $("#arrow").toggleClass("fa-arrow-up").toggleClass("fa-arrow-down");
+    });
+  }
+
+  return {
+    init: init
+  };
 });

--- a/app/views/static_pages/show.html.erb
+++ b/app/views/static_pages/show.html.erb
@@ -44,11 +44,3 @@
     </div>
   </div>
 <% end %>
-
-<script>
-  $("#revisions-anchor").click(function(e){
-    e.preventDefault();
-    $("#revisions").toggle();
-    $("#arrow").toggleClass("fa-arrow-up").toggleClass("fa-arrow-down");
-  });
-</script>


### PR DESCRIPTION
There was a duplicate script block at the bottom of the static_pages show template. I believe this was causing a conflict between the global defined script performing exacting the same action.

PT => https://www.pivotaltracker.com/story/show/76848756