### PR TITLE
Trace start and end of broadcasting at hangouts.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,6 +570,3 @@ DEPENDENCIES
   will_paginate-bootstrap
   yui-compressor
   zeus
-
-BUNDLED WITH
-   1.10.3

--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -57,7 +57,8 @@ class EventInstancesController < ApplicationController
       user_id: params[:host_id],
       participants: params[:participants],
       hangout_url: params[:hangout_url],
-      yt_video_id: params[:yt_video_id]).permit!
-
+      yt_video_id: params[:yt_video_id],
+      hoa_status: params[:hoa_status]
+    ).permit!
   end
 end

--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -16,12 +16,14 @@ class EventInstance < ActiveRecord::Base
   after_save "tweet_hangout_notification if (started? && hangout_url_changed?)"
   after_save "tweet_yt_link if yt_video_id_changed?"
 
+  validate :dont_update_after_finished, on: :update
+
   def started?
     hangout_url?
   end
 
   def live?
-    started? && updated_at > 5.minutes.ago
+    started? && hoa_status != 'finished' && updated_at > 2.minutes.ago
   end
 
   def duration
@@ -70,6 +72,12 @@ class EventInstance < ActiveRecord::Base
       Net::HTTP.get(uri)
     else
       'Video not found'
+    end
+  end
+
+  def dont_update_after_finished
+    if hoa_status_was == 'finished'
+      self.errors.add :base, "Can't update a finished event"
     end
   end
 end

--- a/app/views/event_instances/_hangout_button.html.erb
+++ b/app/views/event_instances/_hangout_button.html.erb
@@ -5,7 +5,7 @@
   'eventId' => event_id.to_s,
   'hostId' => current_user.id,
   'hangoutId' => event_instance_id.present? ? event_instance_id : generate_event_instance_id(current_user, project_id),
-  'callbackUrl' => hangout_url('id').gsub(/id$/, '')
+  'callbackUrl' => hangout_url('id').gsub(/id$/, '').sub(/^#{request.scheme}:/, '')
 }) %>
 
 <div id="liveHOA-placeholder"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,7 +42,7 @@ disqus:
   secret_key: 'bRtQeANt2qJQ9Y6CJZtA2I2g6dioHKDuPaX5US17JmRXmvMYcG69wZXeKaFmd8qJ'
 
 hangouts:
-  app_id: '227702023966'
+  app_id: <%= ENV['HANGOUTS_APP_ID'] %>
 
 twitter:
   consumer_key:        nil

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,12 +3,12 @@ features:
     enabled: true
   slack:
     notifications:
-      enabled: true
+      enabled: <%= ENV['SLACK_NOTIFICATIONS_ENABLED'] %>
     invites:
       enabled: true
   twitter:
     notifications:
-      enabled: true
+      enabled: <%= ENV['TWITTER_NOTIFICATIONS_ENABLED'] %>
 
 mailer:
   delivery_method: 'smtp'

--- a/db/migrate/20150520184236_add_hoa_status_to_event_instances.rb
+++ b/db/migrate/20150520184236_add_hoa_status_to_event_instances.rb
@@ -1,0 +1,7 @@
+class AddHoaStatusToEventInstances < ActiveRecord::Migration
+  def change
+    add_column :event_instances, :hoa_status, :string
+    EventInstance.reset_column_information
+    EventInstance.update_all(hoa_status: 'finished')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150410173625) do
+ActiveRecord::Schema.define(version: 20150520184236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20150410173625) do
     t.integer  "user_id"
     t.string   "yt_video_id"
     t.text     "participants"
+    t.string   "hoa_status"
   end
 
   create_table "events", force: true do |t|

--- a/features/hangout.feature
+++ b/features/hangout.feature
@@ -30,8 +30,8 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
   Scenario: Show hangout details
     Given the Hangout for event "Scrum" has been started with details:
       | EventInstance link | http://hangout.test |
-      | Started at         | 10:25:00            |
-    And the time now is "10:29:00 UTC"
+      | Started at         | 10:25:00 UTC        |
+    And the time now is "10:26:00 UTC"
     When I am on the show page for event "Scrum"
     Then I should see Hangouts details section
     And I should see:
@@ -40,7 +40,7 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
       | Title               |
       | Daily scrum meeting |
       | Updated             |
-      | 4 minutes ago       |
+      | 1 minute ago        |
     And I should see link "http://hangout.test" with "http://hangout.test"
 
   @javascript
@@ -84,10 +84,10 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
 
   @time-travel-step
   Scenario: Render Join live event link
-    Given the date is "2014/02/03 07:04:00 UTC"
+    Given the date is "2014/02/03 07:01:00 UTC"
     And the Hangout for event "Scrum" has been started with details:
       | EventInstance link | http://hangout.test |
-      | Started at         | 07:00:00            |
+      | Started at         | 07:00:00 UTC        |
 
     When I am on the show page for event "Scrum"
     Then I should see link "EVENT IS LIVE" with "http://hangout.test"

--- a/features/step_definitions/hangout_steps.rb
+++ b/features/step_definitions/hangout_steps.rb
@@ -17,7 +17,7 @@ Given /^the Hangout for event "([^"]*)" has been started with details:$/ do |eve
   hangout = ho_details[0]
 
 
-  start_time = hangout['Started at'] ? hangout['Started at'] : Time.now
+  start_time = hangout['Started at'] ? Time.parse(hangout['Started at']) : Time.now
   event = Event.find_by_name(event_name)
 
   FactoryGirl.create(:event_instance, event: event,

--- a/spec/controllers/event_instances_controller_spec.rb
+++ b/spec/controllers/event_instances_controller_spec.rb
@@ -56,8 +56,13 @@ describe EventInstancesController do
       get :update, params.merge(notify: 'true')
     end
 
-    it 'does not call the SlackService' do
+    it 'does not call the SlackService if not update' do
       allow_any_instance_of(EventInstance).to receive(:update).and_return(false)
+      expect(SlackService).not_to receive(:post_hangout_notification).with(an_instance_of(EventInstance))
+      get :update, params.merge(notify: 'true')
+    end
+
+    it 'does not call the SlackService if not notify' do
       expect(SlackService).not_to receive(:post_hangout_notification).with(an_instance_of(EventInstance))
       get :update, params.merge(notify: 'false')
     end
@@ -72,6 +77,16 @@ describe EventInstancesController do
       allow(controller).to receive(:local_request?).and_return(true)
       get :update, params.merge(event_id: '50')
       expect(response).to redirect_to(event_path(50))
+    end
+
+    it 'update EventInstance with permited params' do
+      upd_params = {
+        "title"=>"title", "project_id"=>"project_id", "event_id"=>"event_id",
+        "category"=>"category", "user_id"=>"host", "participants"=>"one, two",
+        "hangout_url"=>"test_url", "yt_video_id"=>"video", "hoa_status"=>"started"
+      }
+      expect_any_instance_of(EventInstance).to receive(:update).with(upd_params)
+      get :update, params.merge(upd_params)
     end
 
     context 'required parametes are missing' do

--- a/spec/factories/event_instances.rb
+++ b/spec/factories/event_instances.rb
@@ -16,8 +16,7 @@ FactoryGirl.define do
     sequence(:title) { |n| "Hangout_#{n}"}
     sequence(:category) { |n| "Category_#{n}"}
     hangout_url "http://hangout.test"
-    yt_video_id 'gCQmvCkLCe8'
-    #sequence(:yt_video_id) { |n| "yt_video_id_#{n}"}
+    sequence(:yt_video_id) { |n| "yt_video_id_#{n}"}
 
     project
     event

--- a/spec/models/event_instance_spec.rb
+++ b/spec/models/event_instance_spec.rb
@@ -17,22 +17,42 @@ describe EventInstance, type: :model do
     end
   end
 
-  context 'hangout_url is present' do
-    before { hangout.hangout_url = 'test' }
+  context 'hangout_url is present and is not finished' do
+    before do
+      hangout.hangout_url = 'test'
+      hangout.hoa_status = 'anything'
+    end
 
-    it 'reports live if the link is not older than 5 minutes' do
-      allow(Time).to receive(:now).and_return(Time.mktime('10:04:59'))
+    it 'reports live if the link is not older than 2 minutes and hoa_status' do
+      allow(Time).to receive(:now).and_return(Time.mktime('10:01:59'))
       expect(hangout.live?).to be_truthy
     end
 
-    it 'reports not live if the link is older than 5 minutes' do
-      allow(Time).to receive(:now).and_return(Time.parse('10:05:01 UTC'))
+    it 'reports not live if the link is older than 2 minutes and hoa_status' do
+      allow(Time).to receive(:now).and_return(Time.parse('10:02:01 UTC'))
       expect(hangout.live?).to be_falsey
     end
 
     it 'calls tweet hangout notification' do
       expect(hangout).to receive(:tweet_hangout_notification)
       hangout.save
+    end
+  end
+
+  context 'hangout_url is present and hoa_status is finished' do
+    before do
+      hangout.hangout_url = 'test'
+      hangout.hoa_status = 'finished'
+    end
+
+    it 'reports not live if the link is not older than 2 minutes' do
+      allow(Time).to receive(:now).and_return(Time.mktime('10:01:59'))
+      expect(hangout.live?).to be_falsey
+    end
+
+    it 'reports not live if the link is older than 2 minutes' do
+      allow(Time).to receive(:now).and_return(Time.parse('10:02:01 UTC'))
+      expect(hangout.live?).to be_falsey
     end
   end
 
@@ -173,6 +193,24 @@ describe EventInstance, type: :model do
         expect(other_hangout).not_to receive(:tweet_hangout_notification)
         other_hangout.save
       end
+    end
+  end
+
+  context 'validation: dont update after finished' do
+    it 'when hoa_status is "finished" should not be updated' do
+      hangout.hangout_url = 'test'
+      hangout.hoa_status = 'finished'
+      hangout.save
+      hangout.reload
+      expect(hangout.update(hoa_status: 'finished')).to be_falsey
+    end
+
+    it 'when hoa_status is not "finished" it is updated' do
+      hangout.hangout_url = 'test'
+      hangout.hoa_status = 'broadcasting'
+      hangout.save
+      hangout.reload
+      expect(hangout.update(hoa_status: 'finished')).to be_truthy
     end
   end
 end

--- a/spec/support/shared_examples/shared_example_for_hangout_button.rb
+++ b/spec/support/shared_examples/shared_example_for_hangout_button.rb
@@ -14,7 +14,7 @@ shared_examples_for 'it has a hangout button' do
       'eventId' => event_id.to_s.squish,
       'hostId' => 'user_1',
       'hangoutId' => '123456',
-      'callbackUrl' => hangout_url('id').gsub(/id$/, '') })
+      'callbackUrl' => hangout_url('id').sub(/id$/, '').sub('http:','') })
     {
       'data-start-data' => start_data,
       'data-app-id' => Settings.hangouts.app_id


### PR DESCRIPTION
* Add column :hoa_status to event_instances table.
* EventInstancesController#update receive hoa_status from
  HangoutConnection
* EventInstance model don't update after set hoa_status to finished
* EventInstance#live? respond true if not finished and updated within 2
  minutes.
* Remove 'request.scheme' from CallbackURL hangout button field, to make
  posible use with either http or https protocol.
* Set Settings.hangout.app_id and Settings.slack.notifications and
  Settings.twitter.notifications to ENV variables to prevent calls from
  development & staging.