### PR TITLE
Use ssl url for communication with hangouts

### DIFF
--- a/app/views/event_instances/_hangout_button.html.erb
+++ b/app/views/event_instances/_hangout_button.html.erb
@@ -5,7 +5,7 @@
   'eventId' => event_id.to_s,
   'hostId' => current_user.id,
   'hangoutId' => event_instance_id.present? ? event_instance_id : generate_event_instance_id(current_user, project_id),
-  'callbackUrl' => hangout_url('id').gsub(/id$/, '').sub(/^#{request.scheme}:/, '')
+  'callbackUrl' => url_for(controller: :event_instances, action: :update, id: 'id', protocol: 'https', host: (Settings.hangouts.ssl_host || root_url[0..-2])).gsub(/id$/, '')
 }) %>
 
 <div id="liveHOA-placeholder"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -43,6 +43,7 @@ disqus:
 
 hangouts:
   app_id: <%= ENV['HANGOUTS_APP_ID'] %>
+  ssl_host: <%= ENV['SSL_HOST'] %>
 
 twitter:
   consumer_key:        nil

--- a/spec/support/shared_examples/shared_example_for_hangout_button.rb
+++ b/spec/support/shared_examples/shared_example_for_hangout_button.rb
@@ -6,28 +6,51 @@ shared_examples_for 'it has a hangout button' do
     allow(view.current_user).to receive(:id).and_return('user_1')
   end
 
-  let(:data_tags) do
-    start_data =  JSON.generate({
-      'title' => title,
-      'category' => category,
-      'projectId' => project_id.to_s.squish,
-      'eventId' => event_id.to_s.squish,
-      'hostId' => 'user_1',
-      'hangoutId' => '123456',
-      'callbackUrl' => hangout_url('id').sub(/id$/, '').sub('http:','') })
-    {
-      'data-start-data' => start_data,
-      'data-app-id' => Settings.hangouts.app_id
-    }
+  context 'with Settings.hangouts.ssl_host' do
+    let(:data_tags) do
+      start_data =  JSON.generate({
+        'title' => title,
+        'category' => category,
+        'projectId' => project_id.to_s.squish,
+        'eventId' => event_id.to_s.squish,
+        'hostId' => 'user_1',
+        'hangoutId' => '123456',
+        'callbackUrl' => "https://my_fancy_host.com/hangouts/"
+      })
+      {
+        'data-start-data' => start_data,
+        'data-app-id' => Settings.hangouts.app_id
+      }
+    end
+
+    it 'renders hangout button with data_tags' do
+      allow(Settings.hangouts).to receive(:ssl_host).and_return('my_fancy_host.com')
+      render
+      expect(rendered).to have_tag('div#liveHOA-placeholder', with: data_tags)
+    end
   end
 
-  it 'renders hangout button with generated hangout id if provided id is empty' do
-    render
-    expect(rendered).to have_tag('div#liveHOA-placeholder', data_tags)
-  end
+  context 'without Settings.hangouts.ssl_host' do
+    let(:data_tags) do
+      start_data =  JSON.generate({
+        'title' => title,
+        'category' => category,
+        'projectId' => project_id.to_s.squish,
+        'eventId' => event_id.to_s.squish,
+        'hostId' => 'user_1',
+        'hangoutId' => '123456',
+        'callbackUrl' => "https://test.host/hangouts/"
+      })
+      {
+        'data-start-data' => start_data,
+        'data-app-id' => Settings.hangouts.app_id
+      }
+    end
 
-  it 'renders hangout button with provided id if it is not empty' do
-    render
-    expect(rendered).to have_tag('div#liveHOA-placeholder', data_tags)
+    it 'renders hangout button with data_tags' do
+      allow(Settings.hangouts).to receive(:ssl_host).and_return(nil)
+      render
+      expect(rendered).to have_tag('div#liveHOA-placeholder', with: data_tags)
+    end
   end
 end


### PR DESCRIPTION
Set the ssl site at `ENV['SSL_HOST']` this value must me `websiteone-production.herokuapp.com`
Then send to hangouts the ssl site at `callbackUrl`, with this value if it is set, otherwise with `root_url`.

At this moment, some disqus test are failing. 

This PR alone will not have effect, until the hot fix done at HangoutConnection will be reverted.