### PR TITLE
Bugfix for Invalid youtube video urls in Slack Notification

### DIFF
--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -10,8 +10,8 @@ class EventInstancesController < ApplicationController
     slack_notify = params[:notify] == 'true'
 
     if event_instance.try!(:update, hangout_params)
-      SlackService.post_hangout_notification(event_instance) if slack_notify || (event_instance.started? && hangout_url_changed)
-      SlackService.post_yt_link(event_instance) if slack_notify || yt_video_id_changed
+      SlackService.post_hangout_notification(event_instance) if (slack_notify && event_instance.hangout_url?) || (event_instance.started? && hangout_url_changed)
+      SlackService.post_yt_link(event_instance) if (slack_notify && event_instance.yt_video_id?) || yt_video_id_changed
 
       TwitterService.tweet_hangout_notification(event_instance) if event_instance.started? && hangout_url_changed
       TwitterService.tweet_yt_link(event_instance) if yt_video_id_changed

--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -7,12 +7,11 @@ class EventInstancesController < ApplicationController
 
     hangout_url_changed = event_instance.hangout_url != hangout_params[:hangout_url]
     yt_video_id_changed = event_instance.yt_video_id != hangout_params[:yt_video_id]
+    slack_notify = params[:notify] == 'true'
 
     if event_instance.try!(:update, hangout_params)
-      if params[:notify] == 'true' then
-        SlackService.post_hangout_notification(event_instance)
-        SlackService.post_yt_link(event_instance)
-      end
+      SlackService.post_hangout_notification(event_instance) if slack_notify || (event_instance.started? && hangout_url_changed)
+      SlackService.post_yt_link(event_instance) if slack_notify || yt_video_id_changed
 
       TwitterService.tweet_hangout_notification(event_instance) if event_instance.started? && hangout_url_changed
       TwitterService.tweet_yt_link(event_instance) if yt_video_id_changed

--- a/spec/controllers/event_instances_controller_spec.rb
+++ b/spec/controllers/event_instances_controller_spec.rb
@@ -56,7 +56,8 @@ describe EventInstancesController do
     context 'slack notification' do
       it 'calls the SlackService to post hangout notification on successful update' do
         expect(SlackService).to receive(:post_hangout_notification).with(an_instance_of(EventInstance))
-        get :update, params.merge(notify: 'true')
+        expect_any_instance_of(EventInstance).to receive(:hangout_url?).at_least(:once).and_return(true)
+        get :update, params.merge(notify: 'true', hangout_url: 'test_url')
       end
 
       it 'does not call the SlackService if not update' do
@@ -72,7 +73,8 @@ describe EventInstancesController do
 
       it 'calls the SlackService to post yt_link on successful update' do
         expect(SlackService).to receive(:post_yt_link).with(an_instance_of(EventInstance))
-        get :update, params.merge(notify: 'true')
+        expect_any_instance_of(EventInstance).to receive(:yt_video_id?).at_least(:once).and_return(true)
+        get :update, params.merge(notify: 'true', yt_video_id: 'test')
       end
 
       it 'does not call the SlackService to post yt_link if not update' do

--- a/spec/controllers/event_instances_controller_spec.rb
+++ b/spec/controllers/event_instances_controller_spec.rb
@@ -101,19 +101,19 @@ describe EventInstancesController do
 
       it 'calls the TwitterService to tweet notification if event has started and hangout url changed' do
         expect(TwitterService).to receive(:tweet_hangout_notification).with(an_instance_of(EventInstance))
-        expect_any_instance_of(EventInstance).to receive(:started?).and_return(true)
+        expect_any_instance_of(EventInstance).to receive(:started?).at_least(:once).and_return(true)
         get :update, params.merge(hangout_url: 'new_hangout_url')
       end
 
       it 'does not call the TwitterService to tweet notification if event has not started' do
         expect(TwitterService).not_to receive(:tweet_hangout_notification).with(an_instance_of(EventInstance))
-        expect_any_instance_of(EventInstance).to receive(:started?).and_return(false)
+        expect_any_instance_of(EventInstance).to receive(:started?).at_least(:once).and_return(false)
         get :update, params.merge(hangout_url: 'new_hangout_url')
       end
 
       it 'does not call the TwitterService to tweet notification if event hangout url has not changed' do
         expect(TwitterService).not_to receive(:tweet_hangout_notification).with(an_instance_of(EventInstance))
-        expect_any_instance_of(EventInstance).to receive(:started?).and_return(true)
+        expect_any_instance_of(EventInstance).to receive(:started?).at_least(:once).and_return(true)
         get :update, params
       end
     end


### PR DESCRIPTION
* Made a few changes in the list of conditions for sending slack notifications so that only valid urls are posted.
* According to the new rules, a slack notification is posted when:
  - A user clicks on the "Notify on slack" button in the hangouts app and the hangout url and youtube video id are present (and not blank).
  - When there is a update in the hangout url or youtube video id. This allows for the youtube notification to be posted only when there is a valid youtube id in the database.

PS - Sorry for the sphagetti code but I couldn't think of a way to make these conditionals better without making things more complex. Any design suggestions are welcome.