### PR TITLE
Fix Blank Youtube Notifications

### DIFF
--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -3,6 +3,7 @@ module SlackService
 
   def post_hangout_notification(hangout)
     return unless Features.slack.notifications.enabled
+    return if hangout.hangout_url.blank?
 
     uri = URI.parse "#{Slack::BOT_URL}/hubot/hangouts-notify"
     Net::HTTP.post_form uri, {
@@ -16,6 +17,7 @@ module SlackService
 
   def post_yt_link(hangout)
     return unless Features.slack.notifications.enabled
+    return if hangout.yt_video_id.blank?
 
     uri = URI.parse "#{Slack::BOT_URL}/hubot/hangouts-video-notify"
     Net::HTTP.post_form uri, {

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -17,6 +17,18 @@ describe SlackService do
          expect(req.body).to eq "title=MockEvent&link=mock_url&type=PairProgramming&host_name=random&host_avatar=#{gravatar}"
        end
      end
+
+     it 'does not post notification if hangout url is blank' do
+       Features.slack.notifications.enabled = true
+       stub_request(:post, 'https://agile-bot.herokuapp.com/hubot/hangouts-notify')
+       user = User.new email: 'random@random.com'
+       gravatar = CGI.escape 'https://www.gravatar.com/avatar/47548e7f026bc689ba743b2af2d391ee?d=retro'
+       hangout = EventInstance.new(title: 'MockEvent', category: "PairProgramming", hangout_url: "     ", user: user)
+
+       subject.post_hangout_notification(hangout)
+
+       assert_not_requested(:post, 'https://agile-bot.herokuapp.com/hubot/hangouts-notify')
+     end
    end
 
    describe '.post_yt_link' do
@@ -33,6 +45,19 @@ describe SlackService do
        assert_requested(:post, 'https://agile-bot.herokuapp.com/hubot/hangouts-video-notify', times: 1) do |req|
          expect(req.body).to eq "title=MockEvent&video=https%3A%2F%2Fyoutu.be%2Fmock_url&type=PairProgramming&host_name=random&host_avatar=#{gravatar}"
        end
+     end
+
+     it 'does not post youtube video link if yt_video_id is blank' do
+       Features.slack.notifications.enabled = true
+       stub_request(:post, 'https://agile-bot.herokuapp.com/hubot/hangouts-video-notify')
+       user = User.new email: 'random@random.com'
+       gravatar = CGI.escape 'https://www.gravatar.com/avatar/47548e7f026bc689ba743b2af2d391ee?d=retro'
+       hangout = EventInstance.create(title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user)
+       hangout.yt_video_id = '    '
+
+       subject.post_yt_link(hangout)
+
+       assert_not_requested(:post, 'https://agile-bot.herokuapp.com/hubot/hangouts-video-notify')
      end
    end
 end


### PR DESCRIPTION
* Add a check in the slack service to make sure that blank notifications don't get sent out to agile-bot

Fixes AgileVentures/agile-bot#2