### PR TITLE
Adds CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,9 @@ We use [Waffle](https://waffle.io/AgileVentures/WebsiteOne) to manage our work o
 git checkout -b 799_add_contributing_md
 ```
 
-Whatever you are working on, or however far you get please open a "Work in Progress" (WIP) [pull request](https://help.github.com/articles/creating-a-pull-request/) so that others in the team can comment on your approach.  Even if you hate your horrible code :-) please throw it up there and we'll help guide your code to fit in with the rest of the project.
+Please ensure that each commit in your pull request makes a single coherent change and that the overall pull request only includes commits related to the specific GitHub issue that the pull request is addressing.  This helps the project managers understand the PRs and merge them more quickly.
+
+Whatever you are working on, or however far you get please do open a "Work in Progress" (WIP) [pull request](https://help.github.com/articles/creating-a-pull-request/) so that others in the team can comment on your approach.  Even if you hate your horrible code :-) please throw it up there and we'll help guide your code to fit in with the rest of the project.
 
 In your pull request description please include the following text, :
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,14 @@ Please ensure that each commit in your pull request makes a single coherent chan
 
 Whatever you are working on, or however far you get please do open a "Work in Progress" (WIP) [pull request](https://help.github.com/articles/creating-a-pull-request/) so that others in the team can comment on your approach.  Even if you hate your horrible code :-) please throw it up there and we'll help guide your code to fit in with the rest of the project.
 
-In your pull request description please include the following text, :
+
+Before you make a pull request it is a great idea to sync again to the upstream develop branch to reduce the chance that there will be any merge conflicts arising from other PRs that have been merged to develop since you started work:
+
+```
+git pull upstream develop
+```
+
+In your pull request description please include the following text:
 
 ```
 fixes #799

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+Development Process
+------------------
+
+Our default working branch is `develop`.  We do work by creating branches off `develop` for new features and bugfixes.  Any feature should include appropriate Cucumber acceptance tests and RSpec unit tests.  We try to avoid view and controller specs, and focus purely on unit tests at the model and service level where possible.  A bugfix may include an acceptance test depending on where the bug occurred, but fixing a bug should start with the creation of a test that replicates the bug, so that any bugfix submission will include an appropriate test as well as the fix itself.
+
+Each developer will usually work with a [fork](https://help.github.com/articles/fork-a-repo/) of the [main repository on Agile Ventures](https://github.com/AgileVentures/WebSiteOne). Before starting work on a new feature or bugfix, please ensure you have [synced your fork to upstream/develop](https://help.github.com/articles/syncing-a-fork/):
+
+```
+git pull upstream develop
+```
+
+Note that you should be re-syncing daily (even hourly at very active times) on your feature/bugfix branch to ensure that you are always building on top of very latest develop code.
+
+We use [Waffle](https://waffle.io/AgileVentures/WebsiteOne) to manage our work on features, chores and bugfixes.  Every pull request should a corresponding GitHub issue, and when you create feature/bug-fix branches please include the id of the relevant issue, e.g.
+
+```
+git checkout -b 799_add_contributing_md
+```
+
+Whatever you are working on, or however far you get please open a "Work in Progress" (WIP) [pull request](https://help.github.com/articles/creating-a-pull-request/) so that others in the team can comment on your approach.  Even if you hate your horrible code :-) please throw it up there and we'll help guide your code to fit in with the rest of the project.
+
+In your pull request description please include the following text, :
+
+```
+fixes #799
+```
+
+which will associate the pull request with the issue in the Waffle board.
+
+Code Style
+-------------
+
+We recommend the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide)
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ git checkout -b 799_add_contributing_md
 
 Please ensure that each commit in your pull request makes a single coherent change and that the overall pull request only includes commits related to the specific GitHub issue that the pull request is addressing.  This helps the project managers understand the PRs and merge them more quickly.
 
-Whatever you are working on, or however far you get please do open a "Work in Progress" (WIP) [pull request](https://help.github.com/articles/creating-a-pull-request/) so that others in the team can comment on your approach.  Even if you hate your horrible code :-) please throw it up there and we'll help guide your code to fit in with the rest of the project.
+Whatever you are working on, or however far you get please do open a "Work in Progress" (WIP) [pull request](https://help.github.com/articles/creating-a-pull-request/) (just prepend your PR title with "[WIP]" ) so that others in the team can comment on your approach.  Even if you hate your horrible code :-) please throw it up there and we'll help guide your code to fit in with the rest of the project.
 
 
 Before you make a pull request it is a great idea to sync again to the upstream develop branch to reduce the chance that there will be any merge conflicts arising from other PRs that have been merged to develop since you started work:
@@ -28,13 +28,24 @@ Before you make a pull request it is a great idea to sync again to the upstream 
 git pull upstream develop
 ```
 
-In your pull request description please include the following text:
+In your pull request description please include a sensible description of your code and a tag `fixes #<issue-id>` e.g. :
 
 ```
+This PR adds a CONTRIBUTING.md file and a docs directory
+
 fixes #799
 ```
 
 which will associate the pull request with the issue in the Waffle board.
+
+Pull Request Review
+-------------------
+
+Currently @tansaku and @diraulo are pairing on the project management of WebSiteOne.  The project managers will review your pull request as soon as possible.  The project managers can merge unilaterally if necessary, but in general both project managers will need to sign off on a pull request before it is merged.
+
+The project managers will review the pull request for coherence with the specified feature or bug fix, and give feedback on code quality, user experience, documentation and git style.  Please respond to comments from the project managers with explanation, or further commits to your pull request in order to get merged in as quickly as possible.
+
+To maximize flexibility add the project managers as collaborators to your WebSiteOne fork in order to allow them to help you fix your pull request, but this is not required.
 
 Code Style
 -------------

--- a/docs/how_to_submit_a_pull_request_on_github.md
+++ b/docs/how_to_submit_a_pull_request_on_github.md
@@ -1,0 +1,5 @@
+:construction: UNDER CONSTRUCTION :construction:
+
+TODO:
+
+ * [ ] pull in contents from http://www.agileventures.org/projects/websiteone/documents/how-to-submit-a-pull-request-on-github


### PR DESCRIPTION
fixes #799 

This is a CONTRIBUTING.md doc based on the one we have for LocalSupport.  GitHub automatically links this file into the UI for pull requests and many developers will expect to find help and advice on how to contribute in this file:

https://help.github.com/articles/setting-guidelines-for-repository-contributors/

This is a proposal based on the approximate workflow I've been following since we switched to waffle, and I'm very interested to hear about how we can word this better, make changes etc. so that we have a workflow that works well for as many of us as possible.