### PR TITLE
brakeman and bundler added

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,8 @@ group :development, :test do
   gem 'guard-cucumber' #plugins for Guard
   gem 'guard-livereload' #plugins for Guard
   gem 'bullet'
+  gem "brakeman", :require => false # detects security vunerabilities in rails apps
+  gem "bundler-audit", :require => false # scans the Gemfile.lock and reports if there are any gems which need to be updated to fix known security issues
 end
 
 group :development, :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,11 +61,26 @@ GEM
     bootstrap-sass (3.3.4.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    brakeman (3.1.5)
+      erubis (~> 2.6)
+      fastercsv (~> 1.5)
+      haml (>= 3.0, < 5.0)
+      highline (>= 1.6.20, < 2.0)
+      multi_json (~> 1.2)
+      ruby2ruby (>= 2.1.1, < 2.3.0)
+      ruby_parser (~> 3.7.0)
+      safe_yaml (>= 1.0)
+      sass (~> 3.0)
+      slim (>= 1.3.6, < 4.0)
+      terminal-table (~> 1.4)
     buftok (0.2.0)
     builder (3.2.2)
     bullet (4.14.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
+    bundler-audit (0.4.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (4.0.5)
       columnize (= 0.9.0)
     capybara (2.4.4)
@@ -167,6 +182,7 @@ GEM
       i18n (~> 0.5)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    fastercsv (1.5.5)
     ffi (1.9.8)
     font-awesome-rails (4.3.0.0)
       railties (>= 3.2, < 5.0)
@@ -198,7 +214,10 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    haml (4.0.7)
+      tilt
     hashie (3.4.1)
+    highline (1.7.8)
     hike (1.2.3)
     hirb (0.7.3)
     hitimes (1.2.2)
@@ -384,6 +403,11 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    ruby2ruby (2.2.0)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.7.3)
+      sexp_processor (~> 4.1)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
     sass (3.4.14)
@@ -401,6 +425,7 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sexp_processor (4.6.1)
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -410,6 +435,9 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
+    slim (3.0.6)
+      temple (~> 0.7.3)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     sprockets (2.12.3)
       hike (~> 1.2)
@@ -422,8 +450,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
     sucker_punch (1.5.0)
       celluloid (~> 0.16.0)
+    temple (0.7.6)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
+    terminal-table (1.5.2)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -496,7 +526,9 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass
+  brakeman
   bullet
+  bundler-audit
   capybara
   capybara-screenshot
   capybara-webkit

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,17 @@
+namespace :brakeman do
+
+  desc 'Run Brakeman'
+  task :run, :output_files do |t, args|
+    require 'brakeman'
+
+    files = args[:output_files].split(' ') if args[:output_files]
+    Brakeman.run :app_path => ".", :output_files => files, :print_report => true
+  end
+
+  desc 'Check your code with Brakeman'
+  task :check do
+    require 'brakeman'
+    result = Brakeman.run app_path: '.', print_report: true
+    exit Brakeman::Warnings_Found_Exit_Code unless result.filtered_warnings.empty?
+  end
+end

--- a/lib/tasks/bundle-audit.rake
+++ b/lib/tasks/bundle-audit.rake
@@ -1,0 +1,12 @@
+if Rails.env.development? || Rails.env.test?
+  require 'bundler/audit/cli'
+
+  namespace :bundler do
+    desc 'Updates the ruby-advisory-db and runs audit'
+    task :audit do
+       %w(update check).each do |command|
+         Bundler::Audit::CLI.start [command]
+       end
+    end
+  end
+end


### PR DESCRIPTION
Resubmission of this PR all fixed up now

This PR adds security auditing tasks but does not put them in the ci build since that would break due to audit failures.
This is because bundler has found a lot of out of date gems with known security vulnerabilities.
Brakeman has found some vulnerabilities too but it does not fail the build (or at least not as configured).
You can see sample output here in the attached files:

[bundler.txt](https://github.com/AgileVentures/WebsiteOne/files/141602/bundler.txt)
[brakeman.txt](https://github.com/AgileVentures/WebsiteOne/files/141603/brakeman.txt)

If you don't want to add it to the default rake task but still want to be able to run "on demand" then just remove the final line in both of the new .rake files and you can run

```
bundle exec rake brakeman:run
```
and

```
bundle exec rake bundler:audit
```
to see the problems

Ultimately I should thing these would be incorporated into the build, once the existing issues are resolved.

