### PR TITLE
855 convert should to expect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
-2016-02-11 @freeranger - Updated the RubyMine logo
-2016-03-03 @freeranger - Remove junk from rspec log
-2016-03-13 @freeranger - Fix Sponsor alignment
+2016-02-11 @freeranger #790 - Updated the RubyMine logo
+2016-03-03 @freeranger #749 - Remove junk from rspec log
+2016-03-13 @freeranger #855 - Convert 'should' to 'expect'
+2016-03-13 @freeranger #900 - Fix Sponsor alignment

--- a/features/step_definitions/articles_steps.rb
+++ b/features/step_definitions/articles_steps.rb
@@ -24,7 +24,7 @@ Then(/^I should see a preview containing:$/) do |table|
   preview_window = windows.last
   page.within_window preview_window do
     content.each do |text|
-      page.should have_text text
+      expect(page).to have_text text
     end
   end
 end

--- a/features/step_definitions/avatar_steps.rb
+++ b/features/step_definitions/avatar_steps.rb
@@ -1,5 +1,5 @@
 Then /^I should see my avatar image$/ do
-  page.should have_xpath("//img[contains(@src, '#{@avatar_link}')]")
+  expect(page).to have_xpath("//img[contains(@src, '#{@avatar_link}')]")
 end
 
 Then /^I should see "([^"]*)" avatars$/ do | arg |

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -242,9 +242,9 @@ Then /^the "([^"]*)" field(?: within (.*))? should( not)? contain "([^"]*)"$/ do
     field_value = (field.tag_name == 'textarea') ? field.text : field.value
     field_value ||= ''
     unless negative
-      field_value.should =~ /#{value}/
+      expect(field_value).to match(/#{value}/)
     else
-      field_value.should_not =~ /#{value}/
+      expect(field_value).to_not match(/#{value}/)
     end
   end
 end
@@ -279,7 +279,7 @@ end
 
 When(/^I should see a selector with options$/) do |table|
   table.rows.flatten.each do |option|
-    page.should have_select(:options => [option])
+    expect(page).to have_select(:options => [option])
   end
 end
 
@@ -309,16 +309,16 @@ end
 
 Then(/^I should (not |)see the very stylish "([^"]*)" button$/) do |should, button|
   if should == 'not '
-    page.should_not have_css %Q{a[title="#{button.downcase}"]}
+    expect(page).to_not have_css %Q{a[title="#{button.downcase}"]}
   else
-    page.should have_css %Q{a[title="#{button.downcase}"]}
+    expect(page).to have_css %Q{a[title="#{button.downcase}"]}
   end
 end
 
 Then(/^I should see the sub-documents in this order:$/) do |table|
   expected_order = table.raw.flatten
   actual_order = page.all('li.listings-item a').collect(&:text)
-  actual_order.should eq expected_order
+  expect(actual_order).to eq expected_order
 end
 
 Then /^I should see a "([^"]*)" table with:$/ do |name, table|

--- a/features/step_definitions/custom_errors_step.rb
+++ b/features/step_definitions/custom_errors_step.rb
@@ -1,13 +1,13 @@
 Then(/^the page should be titled "(.*?)"$/) do |title|
-  page.source.should have_css("title", :text => title, :visible => false)
+  expect(page.source).to have_css("title", :text => title, :visible => false)
 end
 
 And(/^the response status should be "([^"]*)"$/) do |code|
-  page.status_code.should eql(code.to_i)
+  expect(page.status_code).to eql(code.to_i)
 end
 
 When(/^I encounter an internal server error$/) do
-  VisitorsController.any_instance.should_receive(:index).and_raise(Exception)
+  expect_any_instance_of(VisitorsController).to receive(:index).and_raise(Exception)
   visit root_path
 end
 

--- a/features/step_definitions/documents_steps.rb
+++ b/features/step_definitions/documents_steps.rb
@@ -38,7 +38,7 @@ When(/^I click the "([^"]*)" button for document "([^"]*)"$/) do |button, docume
 end
 
 When(/^I should not see the document "([^"]*)"$/) do |title|
-  page.should_not have_selector('title', text: title)
+  expect(page).not_to have_selector('title', text: title)
 end
 
 When(/^I click the sidebar link "([^"]*)"$/) do |link|

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -1,10 +1,10 @@
 And /^(?:The user|I) should receive a "(.*?)" email$/ do |subject|
-  ActionMailer::Base.deliveries.size.should eq 1
+  expect(ActionMailer::Base.deliveries.size).to eq 1
   expect(ActionMailer::Base.deliveries[0].subject).to include(subject)
 end
 
 And /^I should not receive an email$/ do
-  ActionMailer::Base.deliveries.size.should eq 0
+  expect(ActionMailer::Base.deliveries.size).to eq 0
 end
 
 And /^the email queue is clear$/ do
@@ -13,7 +13,7 @@ end
 
 When(/^replies to that email should go to "([^"]*)"$/) do |email|
   @email = ActionMailer::Base.deliveries.last
-  @email.reply_to.should include email
+  expect(@email.reply_to).to include email
 end
 
 Given(/^I click on the retrieve password link in the last email$/) do

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -43,10 +43,10 @@ end
 Then(/^I should be on the Events "([^"]*)" page$/) do |page|
   case page.downcase
     when 'index'
-      current_path.should eq events_path
+      expect(current_path).to eq events_path
 
     when 'create'
-      current_path.should eq events_path
+      expect(current_path).to eq events_path
     else
       pending
   end
@@ -54,12 +54,12 @@ end
 
 Then(/^I should see multiple "([^"]*)" events$/) do |event|
   #puts Time.now
-  page.all(:css, 'a', text: event, visible: false).count.should be > 1
+  expect(page.all(:css, 'a', text: event, visible: false).count).to be > 1
 end
 
 When(/^the next event should be in:$/) do |table|
   table.rows.each do |period, interval|
-    page.should have_content([period, interval].join(' '))
+    expect(page).to have_content([period, interval].join(' '))
   end
 end
 
@@ -73,9 +73,9 @@ Then(/^I should be on the event "([^"]*)" page for "([^"]*)"$/) do |page, name|
   page.downcase!
   case page
     when 'show'
-      current_path.should eq event_path(event)
+      expect(current_path).to eq event_path(event)
     else
-      current_path.should eq eval("#{page}_event_path(event)")
+      expect(current_path).to eq eval("#{page}_event_path(event)")
   end
 end
 

--- a/features/step_definitions/guides_steps.rb
+++ b/features/step_definitions/guides_steps.rb
@@ -1,3 +1,3 @@
 Then(/^I should see a list of guides$/) do
-  page.should have_css "ul#guides-list"
+  expect(page).to have_css "ul#guides-list"
 end

--- a/features/step_definitions/layout_steps.rb
+++ b/features/step_definitions/layout_steps.rb
@@ -1,13 +1,13 @@
 Then(/^I(?:| should) see a navigation header$/) do
-  page.should have_selector('.masthead')
+  expect(page).to have_selector('.masthead')
 end
 
 Then(/^I should see a main content area$/) do
-  page.should have_selector '#main'
+  expect(page).to have_selector '#main'
 end
 
 Then(/^I should see a footer area$/) do
-  page.should have_selector '#footer'
+  expect(page).to have_selector '#footer'
 end
 
 Then(/^I should see a navigation bar$/) do
@@ -16,13 +16,13 @@ end
 
 When(/^I should see "([^"]*)" in footer$/) do |string|
   within('#footer') do
-    page.should have_text string
+    expect(page).to have_text string
   end
 end
 
 Then /^I should see link$/ do |table|
   table.rows.flatten.each do |link|
-    page.should have_link link
+    expect(page).to have_link link
   end
 end
 
@@ -30,19 +30,19 @@ When(/^the page should include ([^"]*) for ([^"]*)$/) do |tag, content|
   case tag
     when 'script'then
       case content
-        when 'Google Analytics' then page.should have_xpath("//script[text()[contains(.,'UA-xxxxxx-x')]]", visible: false)
+        when 'Google Analytics' then expect(page).to have_xpath("//script[text()[contains(.,'UA-xxxxxx-x')]]", visible: false)
       end
-    when 'css' then page.should have_xpath("//link[contains(@href, '#{content}')]", visible: false)
-    when 'js' then page.should have_xpath("//script[contains(@src, '#{content}')]", visible: false)
+    when 'css' then expect(page).to have_xpath("//link[contains(@href, '#{content}')]", visible: false)
+    when 'js' then expect(page).to have_xpath("//script[contains(@src, '#{content}')]", visible: false)
 
   end
 end
 
 Then /^I should see the tracking code$/ do
-  page.should have_xpath("//script[text()[contains(.,#{GA.tracker})]]", visible: false)
+  expect(page).to have_xpath("//script[text()[contains(.,#{GA.tracker})]]", visible: false)
 end
 
 
 Then(/^I should see a modal window with a form "([^"]*)"$/) do |arg|
-  page.should have_content(arg)
+  expect(page).to have_content(arg)
 end

--- a/features/step_definitions/mercury_steps.rb
+++ b/features/step_definitions/mercury_steps.rb
@@ -59,7 +59,7 @@ When(/^I click on the "Insert Media" button$/) do
 end
 
 Then(/^the Mercury Editor modal window should (not |)be visible$/) do |visible|
-  page.should have_css '.mercury-modal', visible: visible.blank?
+  expect(page).to have_css '.mercury-modal', visible: visible.blank?
 end
 
 And(/^I am focused on the "([^"]*)"$/) do |item|

--- a/features/step_definitions/pages_steps.rb
+++ b/features/step_definitions/pages_steps.rb
@@ -58,14 +58,14 @@ Given(/^the page "([^"]*)" has a child page with title "([^"]*)"$/) do |parent, 
 end
 
 Then(/^the current page url should be "([^"]*)"$/) do |url|
-  current_path.should == "/#{url}"
+  expect(current_path).to eq "/#{url}"
 end
 
 Then(/^I should see ancestry "([^"]*)"$/) do |str|
   ancestry = str.split(" >> ")
   within("#ancestry") do
     ancestry.each do |a|
-      page.should have_content a
+      expect(page).to have_content a
     end
   end
 end

--- a/features/step_definitions/projects_steps.rb
+++ b/features/step_definitions/projects_steps.rb
@@ -1,10 +1,10 @@
 Then(/^I should see "([^"]*)" table$/) do |legend|
-  page.should have_css 'h1', text: legend
+  expect(page).to have_css 'h1', text: legend
 end
 
 When(/^I should see column "([^"]*)"$/) do |column|
   within('table#projects thead') do
-    page.should have_css('th', :text => column)
+    expect(page).to have_css('th', :text => column)
   end
 end
 
@@ -32,8 +32,8 @@ end
 Then /^I should see a form for "([^"]*)"$/ do |form_purpose|
   case form_purpose
     when 'creating a new project'
-      page.should have_text form_purpose
-      page.should have_css('form#new_project')
+      expect(page).to have_text form_purpose
+      expect(page).to have_css('form#new_project')
 
     else
       pending

--- a/features/step_definitions/scrums_steps.rb
+++ b/features/step_definitions/scrums_steps.rb
@@ -18,7 +18,7 @@ Then(/^I should see a modal window with the (first|second) scrum$/) do |ord|
 end
 
 Then(/^I should not see a modal window$/) do
-  page.evaluate_script("$('.modal').css('display')").should eq "none"
+  expect(page.evaluate_script("$('.modal').css('display')")).to eq "none"
 end
 
 When(/^I click the first scrum in the timeline$/) do

--- a/features/step_definitions/sponsors_steps.rb
+++ b/features/step_definitions/sponsors_steps.rb
@@ -1,4 +1,4 @@
 Then(/^I should see sponsor banner for "(.*?)"$/) do |supporter_name|
-  page.should have_selector('div#sponsorsBar')
-  page.should have_css("img[alt*='#{supporter_name}']")
+  expect(page).to have_selector('div#sponsorsBar')
+  expect(page).to have_css("img[alt*='#{supporter_name}']")
 end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -136,64 +136,64 @@ end
 
 ### THEN ###
 Then /^I should be signed in$/ do
-  page.should have_content "Log out"
-  page.should_not have_content "Sign up"
-  page.should_not have_content "Log in"
+  expect(page).to have_content "Log out"
+  expect(page).to_not have_content "Sign up"
+  expect(page).to_not have_content "Log in"
 end
 
 Then /^I should be signed out$/ do
-  page.should have_content "Sign up"
-  page.should have_content "Log in"
-  page.should_not have_content "Log out"
+  expect(page).to have_content "Sign up"
+  expect(page).to have_content "Log in"
+  expect(page).to_not have_content "Log out"
 end
 
 Then /^I see an unconfirmed account message$/ do
-  page.should have_content "You have to confirm your account before continuing."
+  expect(page).to have_content "You have to confirm your account before continuing."
 end
 
 Then /^I see a successful sign in message$/ do
-  page.should have_content "Signed in successfully."
+  expect(page).to have_content "Signed in successfully."
 end
 
 Then /^I should see a successful sign up message$/ do
-  page.should have_content "Welcome! You have signed up successfully."
+  expect(page).to have_content "Welcome! You have signed up successfully."
 end
 
 Then /^I should see an invalid email message$/ do
-  page.should have_content "Email is invalid"
+  expect(page).to have_content "Email is invalid"
 end
 
 Then /^I should see a missing password message$/ do
-  page.should have_content "Password can't be blank"
+  expect(page).to have_content "Password can't be blank"
 end
 
 Then /^I should see a missing password confirmation message$/ do
-  page.should have_content "Password confirmation doesn't match"
+  expect(page).to have_content "Password confirmation doesn't match"
 end
 
 Then /^I should see a mismatched password message$/ do
-  page.should have_content "Password confirmation doesn't match"
+  expect(page).to have_content "Password confirmation doesn't match"
 end
 
 Then /^I should see a signed out message$/ do
-  page.should have_content "Signed out successfully."
+  expect(page).to have_content "Signed out successfully."
 end
 
 Then /^I see an invalid login message$/ do
-  page.should have_content "Invalid email or password."
+  expect(page).to have_content "Invalid email or password."
 end
 
 Then /^I should see an account edited message$/ do
-  page.should have_content "You updated your account successfully."
+  expect(page).to have_content "You updated your account successfully."
 end
 
 Then /^I should (not |)see my name$/ do |should|
   create_user
   # TODO Bryan: refactor to display_name
   if should == 'not '
-    page.should_not have_content @user.presenter.display_name
+    expect(page).to_not have_content @user.presenter.display_name
   else
-    page.should have_content @user.presenter.display_name
+    expect(page).to have_content @user.presenter.display_name
   end
 end
 
@@ -201,9 +201,9 @@ Then /^I should (not |)see my gravatar$/ do |should|
   create_user
   # TODO Bryan: refactor to display_name
   if should == 'not '
-    page.should_not have_css 'a[href="' + user_path(@user) + '"] img.projects-user-avatar'
+    expect(page).to_not have_css 'a[href="' + user_path(@user) + '"] img.projects-user-avatar'
   else
-    page.should have_css 'a[href="' + user_path(@user) + '"] img.projects-user-avatar'
+    expect(page).to have_css 'a[href="' + user_path(@user) + '"] img.projects-user-avatar'
   end
 end
 
@@ -253,7 +253,7 @@ end
 
 When(/^I should see a list of all users$/) do
   #this is up to refactoring. Just a quick fix to get things rolling /Thomas
-  page.should have_content 'All users'
+  expect(page).to have_content 'All users'
 end
 
 When(/^I click pulldown link "([^"]*)"$/) do |text|
@@ -294,9 +294,9 @@ end
 
 Then(/^I (should not|should)? see my email$/) do |option|
   if option == "should"
-    page.should have_content @user.email
+    expect(page).to have_content @user.email
   else
-    page.should_not have_content @user.email
+    expect(page).to_not have_content @user.email
   end
 end
 
@@ -316,7 +316,7 @@ When(/^I set my ([^"]*) to be (public|private)?$/) do |value, option|
   else
     #uncheck "Display #{value}"
     find("input#user_display_#{value}").set(false)
-    find("input#user_display_#{value}").should_not be_checked
+    expect(find("input#user_display_#{value}")).to_not be_checked
   end
 end
 
@@ -327,7 +327,7 @@ When(/^I set ([^"]*) to be (true|false)?$/) do |value, option|
     check("user_#{value}")
   else
     uncheck "user_#{value}"
-    find("input#user_#{value}").should_not be_checked
+    expect(find("input#user_#{value}")).to_not be_checked
   end
 end
 
@@ -343,9 +343,9 @@ end
 
 Then(/^"([^"]*)" (should|should not) be checked$/) do |name, option|
   if option == 'should'
-    page.find(:css, "input#user_#{name.underscore}").should be_checked
+    expect(page.find(:css, "input#user_#{name.underscore}")).to be_checked
   else
-    page.find(:css, "input#user_#{name.underscore}").should_not be_checked
+    expect(page.find(:css, "input#user_#{name.underscore}")).to_not be_checked
   end
 end
 
@@ -382,7 +382,7 @@ Given(/^I add a new skill: "(.*)"/) do |skills|
 end
 
 Then(/^I should see skills "(.*)" on my profile/) do |skills|
-  page.all(:css, "#skills-show span").collect { |e| e.text }.sort.should == skills.split(",").sort
+  expect(page.all(:css, "#skills-show span").collect { |e| e.text }.sort).to == skills.split(",").sort
 end
 
 And(/^I have a GitHub profile with username "([^"]*)"$/) do |username|

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -230,7 +230,7 @@ describe ArticlesController do
       @user = double('User')
       controller.stub(:current_user).and_return(@user)
       patch :preview, @params
-      assigns(:author).should eq @user
+      expect(assigns(:author)).to eq @user
       expect(assigns(:article).created_at).to_not be_nil
       expect(assigns(:article).created_at).to_not be_nil
     end

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -27,26 +27,26 @@ describe AuthenticationsController do
 
       @auth = double(Authentication)
       @auths = [@auth]
-      @user.should_receive(:authentications).at_least(1).and_return @auths
-      @auths.should_receive(:find).and_return @auth
+      expect(@user).to receive(:authentications).at_least(1).and_return @auths
+      expect(@auths).to receive(:find).and_return @auth
       @auth.stub(destroy: true)
     end
 
     it 'should require authentication' do
-      controller.should_receive(:authenticate_user!)
+      expect(controller).to receive(:authenticate_user!)
       get :destroy, id: 1
     end
 
     it 'should be removable for users with a password' do
-      @auths.should_receive(:count).and_return 2
-      @auth.should_receive(:destroy).and_return true
+      expect(@auths).to receive(:count).and_return 2
+      expect(@auth).to receive(:destroy).and_return true
       get :destroy, id: 1
       expect(flash[:notice]).to eq 'Successfully removed profile.'
     end
 
     it 'should not be allowed for users without any other means of authentication' do
-      @auths.should_receive(:count).and_return 1
-      @user.should_receive(:encrypted_password).and_return nil
+      expect(@auths).to receive(:count).and_return 1
+      expect(@user).to receive(:encrypted_password).and_return nil
       get :destroy, id: 1
       expect(flash[:alert]).to eq 'Bad idea!'
     end
@@ -66,8 +66,8 @@ describe AuthenticationsController do
 
     it 'should sign in the correct user for existing profiles' do
       @auth = double(Authentication, user: @user)
-      Authentication.should_receive(:find_by_provider_and_uid).and_return @auth
-      controller.should_receive(:sign_in_and_redirect) do
+      expect(Authentication).to receive(:find_by_provider_and_uid).and_return @auth
+      expect(controller).to receive(:sign_in_and_redirect) do
         controller.redirect_to root_path
       end
       get :create, provider: @provider
@@ -76,14 +76,14 @@ describe AuthenticationsController do
 
     context 'for new profiles' do
       before(:each) do
-        Authentication.should_receive(:find_by_provider_and_uid).and_return nil
-        User.should_receive(:new).and_return(@user)
+        expect(Authentication).to receive(:find_by_provider_and_uid).and_return nil
+        expect(User).to receive(:new).and_return(@user)
       end
 
       it 'should create a new user for non-existing profiles' do
         Mailer.stub_chain :send_welcome_message, :deliver
-        @user.should_receive(:save).and_return(true)
-        controller.should_receive(:sign_in_and_redirect) do
+        expect(@user).to receive(:save).and_return(true)
+        expect(controller).to receive(:sign_in_and_redirect) do
           controller.redirect_to root_path
         end
         get :create, provider: @provider
@@ -91,7 +91,7 @@ describe AuthenticationsController do
       end
 
       it 'should redirect to the new user form if there is an error' do
-        @user.should_receive(:save).and_return(false)
+        expect(@user).to receive(:save).and_return(false)
         get :create, provider: @provider
         expect(response).to redirect_to new_user_registration_path
       end
@@ -127,7 +127,7 @@ describe AuthenticationsController do
       it 'should be able to create other profiles' do
         other_auths = %w( Glitter Smoogle HitPub )
         other_auths.each do |p|
-          @auth.should_receive(:save).and_return true
+          expect(@auth).to receive(:save).and_return true
           get :create, provider: p
           expect(flash[:notice]).to eq 'Authentication successful.'
           expect(response).to redirect_to @path
@@ -135,7 +135,7 @@ describe AuthenticationsController do
       end
 
       it 'should not accept multiple profiles from the same source' do
-        @auth.should_receive(:save).and_return false
+        expect(@auth).to receive(:save).and_return false
         get :create, provider: @provider
         expect(flash[:alert]).to eq 'Unable to create additional profiles.'
         expect(response).to redirect_to @path

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -39,7 +39,7 @@ describe DocumentsController do
       end
 
       it 'assigns the requested document as @document' do
-        assigns(:document).should eq(document)
+        expect(assigns(:document)).to eq(document)
       end
 
       it 'renders the show template' do
@@ -115,7 +115,7 @@ describe DocumentsController do
     before(:each) { get :new, {project_id: document.project.friendly_id}, valid_session }
 
     it 'assigns a new document as @document' do
-      assigns(:document).should be_a_new(Document)
+      expect(assigns(:document)).to be_a_new(Document)
     end
 
     it 'renders the new template' do
@@ -134,8 +134,8 @@ describe DocumentsController do
 
       it 'assigns a newly created document as @document' do
         post :create, {project_id: document.project.friendly_id, :document => valid_attributes}, valid_session
-        assigns(:document).should be_a(Document)
-        assigns(:document).should be_persisted
+        expect(assigns(:document)).to be_a(Document)
+        expect(assigns(:document)).to be_persisted
       end
 
       it 'redirects to the created document' do
@@ -155,8 +155,8 @@ describe DocumentsController do
         # Trigger the behavior that occurs when invalid params are submitted
         Document.any_instance.stub(:save).and_return(false)
         post :create, {project_id: document.project.friendly_id, :document => { title: 'invalid value' }}, valid_session
-        assigns(:document).should be_a_new(Document)
-        assigns(:document).should_not be_persisted
+        expect(assigns(:document)).to be_a_new(Document)
+        expect(assigns(:document)).to_not be_persisted
       end
 
       it 're-renders the new template' do
@@ -180,7 +180,7 @@ describe DocumentsController do
     it 'redirects to the documents list' do
       id = @document.project.id
       delete :destroy, {:id => @document.to_param, project_id: @document.project.friendly_id}, valid_session
-      response.should redirect_to(project_documents_path(id))
+      expect(response).to redirect_to(project_documents_path(id))
     end
   end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -117,7 +117,7 @@ describe EventsController do
     end
 
     it 'should require the user to be signed in' do
-      controller.should_receive(:authenticate_user!)
+      expect(controller).to receive(:authenticate_user!)
       post :update, valid_attributes
     end
 

--- a/spec/controllers/newsletters_controller_spec.rb
+++ b/spec/controllers/newsletters_controller_spec.rb
@@ -94,8 +94,8 @@ describe NewslettersController do
     describe "PUT update" do
       describe "with valid params" do
         it "updates the requested newsletter" do
-          newsletter = FactoryGirl.create(:newsletter) 
-          Newsletter.any_instance.should_receive(:update).with({ "title" => "MyString" })
+          newsletter = FactoryGirl.create(:newsletter)
+          expect_any_instance_of(Newsletter).to receive(:update).with({ "title" => "MyString" })
           put :update, {:id => newsletter.to_param, :newsletter => { "title" => "MyString" }}, valid_session
         end
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -39,7 +39,7 @@ describe RegistrationsController do
 
       it 'sets omniauth session to nil' do
         post :create, user: {email: 'random2@random.com', password: 'randomrando', password_confirmation: 'randomrandom'}
-        session[:omniauth].should eq nil
+        expect(session[:omniauth]).to eq nil
       end
     end
   end
@@ -65,7 +65,7 @@ describe RegistrationsController do
     end
 
     it 'assigns the requested project as @project' do
-      @user.should_receive(:update_attributes)
+      expect(@user).to receive(:update_attributes)
       put :update, id: 'update', user: {display_hire_me: true}
       expect(assigns(:user)).to eq(@user)
     end

--- a/spec/controllers/visitors_controller_spec.rb
+++ b/spec/controllers/visitors_controller_spec.rb
@@ -9,7 +9,7 @@ describe VisitorsController do
 
   it 'assigns event to next_occurrence' do
     event = double(Event)
-    Event.should_receive(:next_occurrence).with(:Scrum).and_return(event)
+    expect(Event).to receive(:next_occurrence).with(:Scrum).and_return(event)
     get :index
     expect(assigns(:event)).to eq event
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -52,19 +52,19 @@ describe ApplicationHelper do
     end
 
     it 'should render the text "this is a text"' do
-      @custom_btn_html.should have_css '[title="this is a text"]'
+      expect(@custom_btn_html).to have_css '[title="this is a text"]'
     end
 
     it 'should render the icon classes "fa fa-icon"' do
-      @custom_btn_html.should have_css '.fa.fa-icon'
+      expect(@custom_btn_html).to have_css '.fa.fa-icon'
     end
 
     it 'should have a link to the root path' do
-      @custom_btn_html.should have_link '', href: root_path
+      expect(@custom_btn_html).to have_link '', href: root_path
     end
 
     it 'should have the id="my-id" and class="btn-random"' do
-      @custom_btn_html.should have_css '#my-id.btn-random'
+      expect(@custom_btn_html).to have_css '#my-id.btn-random'
     end
   end
 
@@ -77,12 +77,12 @@ describe ApplicationHelper do
 
     it 'should render the correct provider' do
       btn_html = helper.social_button 'github'
-      btn_html.should have_css '.btn-github'
+      expect(btn_html).to have_css '.btn-github'
     end
 
     it 'should render the delete method if the option is specified' do
       btn_html = helper.social_button 'gplus', delete: true
-      btn_html.should have_css '[method=delete]'
+      expect(btn_html).to have_css '[method=delete]'
     end
   end
 end

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -7,13 +7,13 @@ describe ArticlesHelper do
     it 'generates a hyperlink to the filtered articles index page' do
       tag = 'hello'
       output = helper.link_to_tags [ tag ]
-      output.should eq link_to(tag, articles_path(tag: tag))
+      expect(output).to eq link_to(tag, articles_path(tag: tag))
     end
 
     it 'generates a comma separated link of tag links with multiple tags' do
       tags = %w( hello world )
       output = helper.link_to_tags tags
-      output.should eq "#{link_to(tags[0], articles_path(tag: tags[0]))}, #{link_to(tags[1], articles_path(tag: tags[1]))}"
+      expect(output).to eq "#{link_to(tags[0], articles_path(tag: tags[0]))}, #{link_to(tags[1], articles_path(tag: tags[1]))}"
     end
   end
 
@@ -23,37 +23,37 @@ describe ArticlesHelper do
       markdown_text = "#heading\nthis is some *markdown* text `with code` and **bold** text"
       output = helper.from_markdown markdown_text
 
-      output.should have_css 'h1'
-      output.should have_css 'em'
-      output.should have_css 'code'
-      output.should have_css 'strong'
+      expect(output).to have_css 'h1'
+      expect(output).to have_css 'em'
+      expect(output).to have_css 'code'
+      expect(output).to have_css 'strong'
     end
 
     it 'should render an empty string when the input is nil' do
       output = helper.from_markdown nil
-      output.should be_empty
+      expect(output).to be_empty
     end
 
     it 'should render "Failed to render markdown" when it CodeRay fails for whatever reason' do
       renderer = ArticlesHelper::CodeRayify.new
       CodeRay.stub(:scan).and_raise Exception
       output = renderer.block_code 'function (a, b, c)', nil
-      output.should have_text 'Failed to render code block'
+      expect(output).to have_text 'Failed to render code block'
     end
 
     it 'should render block code correctly' do
       output = helper.from_markdown "this is an example:\n\n~~~ruby\nputs \"hello world\"\n~~~"
 
-      output.should_not have_text '~~~'
-      output.should_not have_text 'ruby'
-      output.should have_css '.code'
+      expect(output).to_not have_text '~~~'
+      expect(output).to_not have_text 'ruby'
+      expect(output).to have_css '.code'
     end
 
     it 'should render block code without a language specified correctly' do
       output = helper.from_markdown "this is an example:\n\n~~~ruby\nplain text\n~~~"
 
-      output.should_not have_text '~~~'
-      output.should have_css '.code'
+      expect(output).to_not have_text '~~~'
+      expect(output).to have_css '.code'
     end
 
     context 'preview' do
@@ -63,24 +63,24 @@ describe ArticlesHelper do
             "\n\n#heading\n until it reaches this heading"
         output = helper.markdown_preview markdown_text
 
-        output.should have_css 'code'
-        output.should have_css 'strong'
-        output.should_not have_css 'h1'
-        output.should_not have_css 'em'
+        expect(output).to have_css 'code'
+        expect(output).to have_css 'strong'
+        expect(output).to_not have_css 'h1'
+        expect(output).to_not have_css 'em'
       end
 
       it 'should not show links or image tags' do
         markdown_text = '`coding` can be really [fun](http://www.google.com) ![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")'
         output = helper.markdown_preview markdown_text
 
-        output.should have_css 'code'
-        output.should_not have_css 'a'
-        output.should_not have_css 'img'
+        expect(output).to have_css 'code'
+        expect(output).to_not have_css 'a'
+        expect(output).to_not have_css 'img'
       end
 
       it 'should render an empty string when the input is nil' do
         output = helper.markdown_preview nil
-        output.should be_empty
+        expect(output).to be_empty
       end
     end
   end

--- a/spec/helpers/devise_helper_spec.rb
+++ b/spec/helpers/devise_helper_spec.rb
@@ -30,7 +30,7 @@ describe DeviseHelper do
       sentence = "There are 2 errors"
       helper.stub_chain(:resource, :errors, :count).and_return @messages.size
       helper.stub_chain(:resource, :class, :model_name, :human).and_return "devise"
-      I18n.should_receive(:t).and_return sentence
+      expect(I18n).to receive(:t).and_return sentence
       result = helper.devise_error_messages_flash
       expect(result).to have_text (sentence)
       expect(result).to have_css ('.alert.alert-danger')

--- a/spec/lib/agile_ventures_bulk_mailer_spec.rb
+++ b/spec/lib/agile_ventures_bulk_mailer_spec.rb
@@ -11,37 +11,36 @@ describe AgileVentures::BulkMailer do
 
   it 'can be initialized' do
     bulk_mailer = AgileVentures::BulkMailer.new(@opts)
-    bulk_mailer.should_not be_nil
+    expect(bulk_mailer).to_not be_nil
   end
 
   it 'will return num sent mails' do
-    AgileVentures::BulkMailer.new(@opts).run.should eq(2)
+    expect(AgileVentures::BulkMailer.new(@opts).run).to eq(2)
   end
 
   it 'responds to #num_sent' do
-    AgileVentures::BulkMailer.new(@opts).should respond_to(:num_sent)
+    expect(AgileVentures::BulkMailer.new(@opts)).to respond_to(:num_sent)
   end
 
   it 'responds to #used_addresses' do
-    AgileVentures::BulkMailer.new(@opts).should respond_to(:used_addresses)
+    expect(AgileVentures::BulkMailer.new(@opts)).to respond_to(:used_addresses)
   end
 
   it 'returns email-addresses' do
     bulk_mailer = AgileVentures::BulkMailer.new(@opts)
     bulk_mailer.run
-    bulk_mailer.used_addresses.sort.should eq(User.all.map(&:email).sort)
+    expect(bulk_mailer.used_addresses.sort).to eq(User.all.map(&:email).sort)
   end
 
   it 'creates and applies instance vars' do
     bulk_mailer = AgileVentures::BulkMailer.new(@opts)
-    bulk_mailer.instance_variables.should include(:@heading &&
+    expect(bulk_mailer.instance_variables).to include(:@heading &&
                                                    :@content &&
                                                    :@subject &&
                                                    :@batch_size
                                                    )
     [:@heading, :@subject].each do |word|
-      bulk_mailer.instance_variable_get(word).should 
-      eq("my #{word.to_s.split('@')[-1]}")
+      expect(bulk_mailer.instance_variable_get(word)).to eq("my #{word.to_s.split('@')[-1]}")
     end
   end
   

--- a/spec/lib/custom_errors_spec.rb
+++ b/spec/lib/custom_errors_spec.rb
@@ -45,7 +45,7 @@ describe CustomErrors, type: 'controller' do
     it 'should be able to adjust log stack trace limit' do
       dummy = Class.new
       Rails.stub(logger: dummy)
-      dummy.should_receive(:error).exactly(7)
+      expect(dummy).to receive(:error).exactly(7)
       get :raise_500
     end
 
@@ -53,7 +53,7 @@ describe CustomErrors, type: 'controller' do
       ActionMailer::Base.deliveries.clear
       get :raise_500
 
-      ActionMailer::Base.deliveries.size.should eq 1
+      expect(ActionMailer::Base.deliveries.size).to eq 1
       email = ActionMailer::Base.deliveries[0]
       expect(email.subject).to include 'ERROR'
 

--- a/spec/mailers/console_mailer_spec.rb
+++ b/spec/mailers/console_mailer_spec.rb
@@ -15,17 +15,17 @@ describe ConsoleMailer do
     let(:mail) { ConsoleMailer.newsletter(@user, valid_params) }
     
     it 'renders the headers' do
-      mail.subject.should eq('specific subject')
-      mail.to.should eq([@user.email])
-      mail.from.should eq(['info@agileventures.org'])
+      expect(mail.subject).to eq('specific subject')
+      expect(mail.to).to eq([@user.email])
+      expect(mail.from).to eq(['info@agileventures.org'])
     end
 
     it 'renders the heading' do
-      mail.body.encoded.should match('my heading')
+      expect(mail.body.encoded).to match('my heading')
     end
 
     it 'renders the body' do
-      mail.body.encoded.should match('my multiline')
+      expect(mail.body.encoded).to match('my multiline')
     end
 
     it 'adds cc to sam' do

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -2,20 +2,20 @@ require 'spec_helper'
 
 describe Newsletter do
   it 'has a valid factory' do
-    FactoryGirl.build(:newsletter).should be_valid
+    expect(FactoryGirl.build(:newsletter)).to be_valid
   end
 
   describe "is invalid" do
     it 'when subejct is empty' do
-      FactoryGirl.build(:newsletter, subject: nil).should_not be_valid
+      expect(FactoryGirl.build(:newsletter, subject: nil)).to_not be_valid
     end
 
     it 'when title is emtpy' do
-      FactoryGirl.build(:newsletter, title: nil).should_not be_valid
+      expect(FactoryGirl.build(:newsletter, title: nil)).to_not be_valid
     end
 
     it 'when body is empty' do
-      FactoryGirl.build(:newsletter, body: nil).should_not be_valid
+      expect(FactoryGirl.build(:newsletter, body: nil)).to_not be_valid
     end
   end
 
@@ -56,7 +56,7 @@ describe Newsletter do
       @newsletter.do_send = true
       @newsletter.save
       @newsletter.reload 
-      @newsletter.sent_at.should be_a(Time)
+      expect(@newsletter.sent_at).to be_a(Time)
     end
 
     it 'updates was_sent to true' do

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -4,6 +4,6 @@ describe 'Assets' do
 
   it 'should have mercury missing-image.png' do
 
-    Rails.application.assets.find_asset('mercury/missing-image.png').should_not be_nil
+    expect(Rails.application.assets.find_asset('mercury/missing-image.png')).to_not be_nil
   end
 end

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -26,13 +26,13 @@ describe 'OmniAuth authentication' do
       context "with a #{name} profile" do
         it 'should work with valid credentials' do
           visit new_user_session_path
-          page.should have_content "#{name}"
+          expect(page).to have_content "#{name}"
           expect {
             expect {
               click_link "#{name}"
             }.to change(User, :count).by(1)
           }.to change(Authentication, :count).by(1)
-          page.should have_content('Signed in successfully.')
+          expect(page).to have_content('Signed in successfully.')
         end
 
         it 'should not work with invalid credentials' do
@@ -43,7 +43,7 @@ describe 'OmniAuth authentication' do
               click_link "#{name}"
             }.to change(User, :count).by(0)
           }.to change(Authentication, :count).by(0)
-          page.should have_content('invalid_credentials')
+          expect(page).to have_content('invalid_credentials')
         end
 
         it 'should not allow removal of profiles without passwords' do
@@ -57,7 +57,7 @@ describe 'OmniAuth authentication' do
               click_link "Remove #{name}"
             }.to change(User, :count).by(0)
           }.to change(Authentication, :count).by(0)
-          page.should have_content 'Bad idea!'
+          expect(page).to have_content 'Bad idea!'
         end
       end
     end
@@ -74,26 +74,26 @@ describe 'OmniAuth authentication' do
 
         it 'finds the right user if auth exists' do
           visit new_user_session_path
-          page.should have_content "#{name}"
+          expect(page).to have_content "#{name}"
           expect {
             expect {
               click_link "#{name}"
             }.to change(User, :count).by(0)
           }.to change(Authentication, :count).by(0)
-          page.should have_content('Signed in successfully.')
+          expect(page).to have_content('Signed in successfully.')
         end
 
         it 'should be removable for users with a password' do
           visit new_user_session_path
           click_link "#{name}"
           visit edit_user_registration_path(@user)
-          page.should have_css "input[value='#{@user.email}']"
+          expect(page).to have_css "input[value='#{@user.email}']"
           expect {
             expect {
               click_link "Remove #{name}"
             }.to change(User, :count).by(0)
           }.to change(Authentication, :count).by(-1)
-          page.should have_content('Successfully removed profile.')
+          expect(page).to have_content('Successfully removed profile.')
         end
 
         it 'should be able to create other profiles' do
@@ -116,7 +116,7 @@ describe 'OmniAuth authentication' do
               'uid'       => "randomplus#{@uid}"
           }
           visit "/auth/#{provider}"
-          page.should have_content 'Unable to create additional profiles.'
+          expect(page).to have_content 'Unable to create additional profiles.'
         end
       end
     end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -6,7 +6,7 @@ describe "Documents" do
 #    it "works! (now write some real specs)" do
 #      # Run the generator again with the --webrat flag if you want to use webrat methods/matchers
 #      get documents_path
-#      response.status.should be(200)
+#      expect(response.status).to be(200)
 #    end
   end
 end

--- a/spec/requests/newsletters_spec.rb
+++ b/spec/requests/newsletters_spec.rb
@@ -4,7 +4,7 @@ describe "Newsletters" do
   describe "GET /newsletters" do
     it "at least it seems okay" do
       get newsletters_path
-      response.status.should be(200)
+      expect(response.status).to be(200)
     end
   end
 end

--- a/spec/routing/documents_routing_spec.rb
+++ b/spec/routing/documents_routing_spec.rb
@@ -5,31 +5,31 @@ describe DocumentsController do
 
     # TODO write route tests
     #it "routes to #index" do
-    #  get("/documents").should route_to("documents#index")
+    #  expect(get("/documents")).to route_to("documents#index")
     #end
     #
     #it "routes to #new" do
-    #  get("/documents/new").should route_to("documents#new")
+    #  expect(get("/documents/new")).to route_to("documents#new")
     #end
     #
     #it "routes to #show" do
-    #  get("/documents/1").should route_to("documents#show", :id => "1")
+    #  expect(get("/documents/1")).to route_to("documents#show", :id => "1")
     #end
     #
     #it "routes to #edit" do
-    #  get("/documents/1/edit").should route_to("documents#edit", :id => "1")
+    #  expect(get("/documents/1/edit")).to route_to("documents#edit", :id => "1")
     #end
     #
     #it "routes to #create" do
-    #  post("/documents").should route_to("documents#create")
+    #  expect(post("/documents")).to route_to("documents#create")
     #end
     #
     #it "routes to #update" do
-    #  put("/documents/1").should route_to("documents#update", :id => "1")
+    #  expect(put("/documents/1")).to route_to("documents#update", :id => "1")
     #end
     #
     #it "routes to #destroy" do
-    #  delete("/documents/1").should route_to("documents#destroy", :id => "1")
+    #  expect(delete("/documents/1")).to route_to("documents#destroy", :id => "1")
     #end
 
   end

--- a/spec/routing/newsletters_routing_spec.rb
+++ b/spec/routing/newsletters_routing_spec.rb
@@ -3,31 +3,31 @@ require "spec_helper"
 describe NewslettersController do
   describe "routing" do
     it "routes to #index" do
-      get("/newsletters").should route_to("newsletters#index")
+      expect(get("/newsletters")).to route_to("newsletters#index")
     end
 
     it "routes to #new" do
-      get("/newsletters/new").should route_to("newsletters#new")
+      expect(get("/newsletters/new")).to route_to("newsletters#new")
     end
 
     it "routes to #show" do
-      get("/newsletters/1").should route_to("newsletters#show", :id => "1")
+      expect(get("/newsletters/1")).to route_to("newsletters#show", :id => "1")
     end
 
     it "routes to #edit" do
-      get("/newsletters/1/edit").should route_to("newsletters#edit", :id => "1")
+      expect(get("/newsletters/1/edit")).to route_to("newsletters#edit", :id => "1")
     end
 
     it "routes to #create" do
-      post("/newsletters").should route_to("newsletters#create")
+      expect(post("/newsletters")).to route_to("newsletters#create")
     end
 
     it "routes to #update" do
-      put("/newsletters/1").should route_to("newsletters#update", :id => "1")
+      expect(put("/newsletters/1")).to route_to("newsletters#update", :id => "1")
     end
 
     it "routes to #destroy" do
-      delete("/newsletters/1").should route_to("newsletters#destroy", :id => "1")
+      expect(delete("/newsletters/1")).to route_to("newsletters#destroy", :id => "1")
     end
   end
 end

--- a/spec/services/event_creator_service_spec.rb
+++ b/spec/services/event_creator_service_spec.rb
@@ -15,14 +15,14 @@ describe EventCreatorService do
   context 'on success creates an event' do
     let(:event) { double(:event, save: true) }
     it 'should display a success message' do
-      service.perform(event_params, callback).should == 'success'
+      expect(service.perform(event_params, callback)).to eq 'success'
     end
   end
 
   context 'on failure display error message' do
     let(:event) { double(:event, save: false) }
     it 'should display a failure message' do
-      service.perform(event_params, callback).should == 'failure'
+      expect(service.perform(event_params, callback)).to eq 'failure'
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,7 +3,7 @@ module Helpers
   # Used to mimic the same method available in feature testing
   # ex.
   #   rendered.within('section#header') do |header|
-  #     header.should have_link 'Log Out'
+  #     expect(header).to have_link 'Log Out'
   #   end
   # String.class_eval used instead of class String because the latter loads this as a constant, not a method!
   # Some insight to difference here: http://stackoverflow.com/a/10339348/2197402

--- a/spec/views/events/new.html.erb_spec.rb
+++ b/spec/views/events/new.html.erb_spec.rb
@@ -12,7 +12,7 @@ describe 'events/new' do
     before :each do
       view.stub(:authenticate_user!).and_return(true)
     #  #@controller.view_context.stub(:authenticate_user!).and_return(false)
-    #  view.should_receive(:user_signed_in?).and_return(false)
+    #  expect(view).to receive(:user_signed_in?).and_return(false)
     end
 
     xit 'should redirect to sign in and render a flash error' do
@@ -24,7 +24,7 @@ describe 'events/new' do
   context 'user is signed in' do
     before :each do
       #@controller.view_context.stub(:authenticate_user!).and_return(true)
-      #view.should_receive(:current_user).and_return(mock(:user))
+      #expect(view_.to receive(:current_user).and_return(mock(:user))
     end
 
     it 'should display form with all form elements' do

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -27,15 +27,15 @@ describe 'layouts/application.html.erb' do
     all_selectors.each do |css_selector|
       it "should have selector #{css_selector}" do
         render
-        rendered.should have_css css_selector, visible: false
+        expect(rendered).to have_css css_selector, visible: false
       end
     end
   end
 
   it 'should include css & js files' do
     render
-    rendered.should have_tag('link', href: /\.css/)
-    rendered.should have_tag('script', href: /\.js/)
+    expect(rendered).to have_tag('link', href: /\.css/)
+    expect(rendered).to have_tag('script', href: /\.js/)
   end
 
   it 'should not have div nested inside p' do
@@ -50,7 +50,7 @@ describe 'layouts/application.html.erb' do
 
   it 'should render a navbar' do
     render
-    rendered.should have_selector('div.navbar')
+    expect(rendered).to have_selector('div.navbar')
   end
 
   it 'should render a search toggle' do
@@ -61,13 +61,13 @@ describe 'layouts/application.html.erb' do
   it 'should render links to site features' do
     render
     #TODO Y replace href with project_path helper
-    rendered.should have_link 'Projects', :href => projects_path
+    expect(rendered).to have_link 'Projects', :href => projects_path
   end
 
   it 'should render a footer' do
     render
-    rendered.should have_selector('footer')
-    rendered.should have_text ('AgileVentures - Crowdsourced Learning')
+    expect(rendered).to have_selector('footer')
+    expect(rendered).to have_text ('AgileVentures - Crowdsourced Learning')
   end
 
   it 'should return 200 for all link visits' do
@@ -77,7 +77,7 @@ describe 'layouts/application.html.erb' do
       links = header.all('a').map { |el| el[:href] }
       links.each do |link|
         visit link
-        page.status_code.should == 200
+        expect(page.status_code).to eq 200
       end
     end
   end
@@ -90,8 +90,8 @@ describe 'layouts/application.html.erb' do
     it 'should render login & sign-up links' do
       render
       rendered.within('header#main_header') do |header|
-        header.should have_link 'Log in', :href => new_user_session_path
-        header.should have_link 'Sign up', :href => new_user_registration_path
+        expect(header).to have_link 'Log in', :href => new_user_session_path
+        expect(header).to have_link 'Sign up', :href => new_user_registration_path
       end
     end
   end
@@ -103,17 +103,17 @@ describe 'layouts/application.html.erb' do
 
     it 'should render navigation links' do
       render
-      rendered.should have_css('#user-gravatar', :visible => true)
-      rendered.should have_link 'My account', :href => user_path(@user), :visible => false
+      expect(rendered).to have_css('#user-gravatar', :visible => true)
+      expect(rendered).to have_link 'My account', :href => user_path(@user), :visible => false
       rendered.within('div.navbar') do |header|
-        header.should_not have_link 'Log in', :href => new_user_session_path
-        header.should_not have_link 'Sign up', :href => new_user_registration_path
+        expect(header).to_not have_link 'Log in', :href => new_user_session_path
+        expect(header).to_not have_link 'Sign up', :href => new_user_registration_path
       end
     end
 
     it 'should return 200 on link visit' do
       visit edit_user_registration_path
-      page.status_code.should == 200
+      expect(page.status_code).to eq 200
     end
 
   end
@@ -123,25 +123,25 @@ describe 'layouts/application.html.erb' do
 
     it 'should render a link to the "About Us" page' do
       rendered.within('#footer') do |footer|
-        footer.should have_link 'About Us', :href => static_page_path('About Us')
+        expect(footer).to have_link 'About Us', :href => static_page_path('About Us')
       end
     end
 
     it 'should render a link to the "Getting Started" page' do
       rendered.within('#footer') do |footer|
-        footer.should have_link 'Getting Started', :href => static_page_path('Getting Started')
+        expect(footer).to have_link 'Getting Started', :href => static_page_path('Getting Started')
       end
     end
 
     it 'should render a link to the AgileVentures Facebook page' do
       rendered.within('#footer') do |footer|
-        footer.should have_link 'Facebook', href: 'https://www.facebook.com/agileventures'
+        expect(footer).to have_link 'Facebook', href: 'https://www.facebook.com/agileventures'
       end
     end
 
     it 'should render a link to the AgileVentures Twitter page' do
       rendered.within('#footer') do |footer|
-        footer.should have_link 'Twitter', href: 'https://twitter.com/AgileVentures'
+        expect(footer).to have_link 'Twitter', href: 'https://twitter.com/AgileVentures'
       end
     end
   end

--- a/spec/views/layouts/articles_layout.html.erb_spec.rb
+++ b/spec/views/layouts/articles_layout.html.erb_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 describe 'layouts/articles_layout' do
   it 'should render a sidebar' do
     render
-    rendered.should have_selector('aside#sidebar')
+    expect(rendered).to have_selector('aside#sidebar')
     rendered.within('aside#sidebar') do |sidebar|
-      sidebar.should have_text('Articles by tags')
-      sidebar.should have_text('Ruby')
-      sidebar.should have_text('Rails')
-      sidebar.should have_text('Javascript')
-      sidebar.should have_text('jQuery')
+      expect(sidebar).to have_text('Articles by tags')
+      expect(sidebar).to have_text('Ruby')
+      expect(sidebar).to have_text('Rails')
+      expect(sidebar).to have_text('Javascript')
+      expect(sidebar).to have_text('jQuery')
     end
   end
 end

--- a/spec/views/layouts/sponsors.html.erb_spec.rb
+++ b/spec/views/layouts/sponsors.html.erb_spec.rb
@@ -3,24 +3,24 @@ require 'spec_helper'
 describe 'layouts/_sponsors' do
 	it 'should render the sponsors sidebar' do
 		render
-		rendered.should have_selector('div#sponsorsBar')
-		rendered.should have_selector('a.sponsorMedal')
+		expect(rendered).to have_selector('div#sponsorsBar')
+		expect(rendered).to have_selector('a.sponsorMedal')
 	end
 
 	it 'should render the become a supporter button' do
 		render
-		rendered.should have_link 'Become a supporter', static_page_path('Sponsors')
+		expect(rendered).to have_link 'Become a supporter', static_page_path('Sponsors')
 	end
 
 	it 'should render the Makers Academy banner' do
 		render
-		response.body.should have_link('', href: "http://www.makersacademy.com/")
-		response.body.should have_selector('a.sponsorMedal img[src*="makers"]')
+		expect(response.body).to have_link('', href: "http://www.makersacademy.com/")
+		expect(response.body).to have_selector('a.sponsorMedal img[src*="makers"]')
   end
 
 	it 'should render the airpair banner' do
 		render
-		response.body.should have_link('', href: "http://www.airpair.com/")
-		response.body.should have_selector('a.sponsorMedal img[src*="sponsors/airpair"]')
+		expect(response.body).to have_link('', href: "http://www.airpair.com/")
+		expect(response.body).to have_selector('a.sponsorMedal img[src*="sponsors/airpair"]')
 	end
 end

--- a/spec/views/layouts/with_sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/with_sidebar.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'layouts/with_sidebar.html.erb' do
   it 'render sidebar' do
     render
-    rendered.should have_css('#sidebar')
-    rendered.should have_css('h3', :text => 'Current Projects')
+    expect(rendered).to have_css('#sidebar')
+    expect(rendered).to have_css('h3', :text => 'Current Projects')
   end
 end

--- a/spec/views/newsletters/show.html.erb_spec.rb
+++ b/spec/views/newsletters/show.html.erb_spec.rb
@@ -10,7 +10,7 @@ describe "newsletters/show" do
 
   it "renders attributes in <p>" do
     render
-    rendered.should match(/Title/)
-    rendered.should match(/My Subject/)
+    expect(rendered).to match /Title/
+    expect(rendered).to match /My Subject/
   end
 end

--- a/spec/views/static_page/show.html.erb_spec.rb
+++ b/spec/views/static_page/show.html.erb_spec.rb
@@ -26,26 +26,26 @@ describe "static_pages/show" do
 
   it 'render page content' do
     render
-    rendered.should have_content @page.title
-    rendered.should have_content @page.body
+    expect(rendered).to have_content @page.title
+    expect(rendered).to have_content @page.body
   end
 
   it 'should not render page revisions history for new pages' do
     render
-    rendered.should_not have_content 'Revisions'
+    expect(rendered).to_not have_content 'Revisions'
   end
 
   it 'should render page revisions history for pages with more than 1 revisions' do
     @page.stub(versions: [ @version, @version ])
     render
-    rendered.should have_content 'Revisions'
+    expect(rendered).to have_content 'Revisions'
   end
 
   it 'renders correct ancestry for static page' do
     render
     rendered.within("#ancestry") do
-      rendered.should have_content "Agile Ventures"
-      rendered.should have_content @page.title
+      expect(rendered).to have_content "Agile Ventures"
+      expect(rendered).to have_content @page.title
     end
   end
 end


### PR DESCRIPTION
Closes #855

Convert should and should_receive to new expect syntax to remove deprecation warnings from the rspec log.
Note: this is all test changes - no application code has been touched