### PR TITLE
Customize error message when GitHub and G+ signup fail due to no public email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'sucker_punch' # Single Process Ruby asynchronous processing library
 gem 'twitter', '~> 5.11.0' # twitter api wrapper
 gem 'jvectormap-rails', '~> 1.0.0' #jVectorMap for the Rails asset pipeline
 
+gem 'active_model-errors_details'
+
+
 group :test do
   gem 'capybara' # Simulates user actions for cucumber
   gem 'cucumber-rails', :require => false # Cucmber features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,9 @@ GEM
       activesupport (= 4.1.6)
       builder (~> 3.1)
       erubis (~> 2.7.0)
+    active_model-errors_details (1.3.0)
+      activemodel (>= 3.2.13, < 5.0.0.beta1)
+      activesupport
     activemodel (4.1.6)
       activesupport (= 4.1.6)
       builder (~> 3.1)
@@ -517,6 +520,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model-errors_details
   acts-as-taggable-on
   acts_as_follower
   acts_as_tree

--- a/features/users/create_users.feature
+++ b/features/users/create_users.feature
@@ -46,10 +46,10 @@ Feature: As a developer
   Scenario: User signs up with a GitHub account having no public email (sad path)
     Given I am on the "registration" page
     When I click "GitHub"
-    Then I should see "Email can't be blank"
+    Then I should see "Your Github account needs to have a public email address for sign up"
 
   @omniauth-without-email
   Scenario: User signs up with a Google+ account having no public email (sad path)
     Given I am on the "registration" page
     When I click "Google+"
-    Then I should see "Email can't be blank"
+    Then I should see "Your Gplus account needs to have a public email address for sign up"


### PR DESCRIPTION
fixes #876 