### PR TITLE
Test driven fix of the timezone issue on the events list page

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -29,7 +29,7 @@
             </div>
             <div class="col-lg-4 col-xs-12 col-sm-4">
               <i class="fa fa-calendar"></i><span class="month"><%= instance[:time].strftime('%a, %b %d, %Y') %></span><br/>
-              <i class="fa fa-clock-o"></i><span><%= raw local_time(event.start_time, '%H:%M') %>-<%= raw local_time(event.instance_end_time, '%H:%M (%Z)') %></span>
+              <i class="fa fa-clock-o"></i><span><%= raw local_time(instance[:time], '%H:%M') %>-<%= raw local_time(instance[:time]+event.duration*60, '%H:%M (%Z)') %></span>
             </div>
             <div class="col-lg-8 col-xs-12 col-sm-8">
               <p><%= event.description.truncate(120, separator: /\s/) %></p>

--- a/features/events/list_repeating_events.feature
+++ b/features/events/list_repeating_events.feature
@@ -1,22 +1,16 @@
 @vcr
-Feature: List Events
+Feature: List Repeating Events
   As a site user
-  So I can find events relevant to me
-  I would like to see a list of events linked to a given project
+  So I can find events relevant to me that are happening now
+  I would like to see repeats of regular events
 
   Background:
-    Given the following projects exist:
-      | title | description          | pitch | status |
-      | cs169 | greetings earthlings |       | active |
     Given following events exist:
       | name       | description             | category        | start_datetime          | duration | repeats | time_zone | project | repeats_weekly_each_days_of_the_week_mask | repeats_every_n_weeks |
       | Standup    | Daily standup meeting   | Scrum           | 2014/02/03 07:00:00 UTC | 150      | weekly  | UTC       |         |   15                                      |     1                 |
-      | PP Session | Pair programming on WSO | PairProgramming | 2014/02/07 10:00:00 UTC | 15       | weekly  | UTC       | cs169   |   15                                      |     1                 |
 
-  @javascript
   Scenario: Show correct timezone
     Given the date is "2016/05/01 09:15:00 UTC"
-    And the browser is in "Europe/London" and the server is in UTC
     And I am on events index page
     Then I should see "Standup"
-    And I should see "08:00-10:30 (BST)"
+    And the local time element should be set to "2016-05-10T07:00:00Z"

--- a/features/events/list_repeating_events.feature
+++ b/features/events/list_repeating_events.feature
@@ -1,0 +1,22 @@
+@vcr
+Feature: List Events
+  As a site user
+  So I can find events relevant to me
+  I would like to see a list of events linked to a given project
+
+  Background:
+    Given the following projects exist:
+      | title | description          | pitch | status |
+      | cs169 | greetings earthlings |       | active |
+    Given following events exist:
+      | name       | description             | category        | start_datetime          | duration | repeats | time_zone | project | repeats_weekly_each_days_of_the_week_mask | repeats_every_n_weeks |
+      | Standup    | Daily standup meeting   | Scrum           | 2014/02/03 07:00:00 UTC | 150      | weekly  | UTC       |         |   15                                      |     1                 |
+      | PP Session | Pair programming on WSO | PairProgramming | 2014/02/07 10:00:00 UTC | 15       | weekly  | UTC       | cs169   |   15                                      |     1                 |
+
+  @javascript
+  Scenario: Show correct timezone
+    Given the date is "2016/05/01 09:15:00 UTC"
+    And the timezone is set
+    And I am on events index page
+    Then I should see "Standup"
+    And I should see "08:00-10:30 (BST)"

--- a/features/events/list_repeating_events.feature
+++ b/features/events/list_repeating_events.feature
@@ -16,7 +16,7 @@ Feature: List Events
   @javascript
   Scenario: Show correct timezone
     Given the date is "2016/05/01 09:15:00 UTC"
-    And the timezone is set
+    And the browser is in "Europe/London" and the server is in UTC
     And I am on events index page
     Then I should see "Standup"
     And I should see "08:00-10:30 (BST)"

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -124,5 +124,6 @@ end
 Given(/^the browser is in "([^"]*)" and the server is in UTC$/) do |tz|
   ENV['TZ'] = tz
   visit root_path
+  sleep(5)
   ENV['TZ'] = 'UTC'
 end

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -127,3 +127,7 @@ Given(/^the browser is in "([^"]*)" and the server is in UTC$/) do |tz|
   sleep(5)
   ENV['TZ'] = 'UTC'
 end
+
+And(/^the local time element should be set to "([^"]*)"$/) do |datetime|
+  expect(page).to have_css "time[datetime='#{datetime}']"
+end

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -121,6 +121,8 @@ And(/^the event named "([^"]*)" is associated with "([^"]*)"$/) do |event_name, 
   expect(event.project.title).to eq project_title
 end
 
-And(/^the timezone is set$/) do
-  ENV['TZ'] = "Europe/London"
+Given(/^the browser is in "([^"]*)" and the server is in UTC$/) do |tz|
+  ENV['TZ'] = tz
+  visit root_path
+  ENV['TZ'] = 'UTC'
 end

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -120,3 +120,7 @@ And(/^the event named "([^"]*)" is associated with "([^"]*)"$/) do |event_name, 
   event = Event.find_by(name: event_name)
   expect(event.project.title).to eq project_title
 end
+
+And(/^the timezone is set$/) do
+  ENV['TZ'] = "Europe/London"
+end


### PR DESCRIPTION
fixes #953

We've been trying to test this, but it relies on being able to set the timezone for the capybara javascript driver, which we can't yet work out how to do - have opened a ticket with capybara: https://github.com/jnicklas/capybara/issues/1685