### PR TITLE
Removes time from hangout_id sent to HangoutConnection (#1015)

### DIFF
--- a/app/helpers/event_instances_helper.rb
+++ b/app/helpers/event_instances_helper.rb
@@ -1,6 +1,5 @@
 module EventInstancesHelper
   def generate_event_instance_id(user, project_id = nil)
-    project_id ||= '00'
-    "#{user.id}#{project_id}#{Time.now.to_i}"
+    "#{user.id}#{project_id || '00'}"
   end
 end

--- a/spec/helpers/event_instances_helper_spec.rb
+++ b/spec/helpers/event_instances_helper_spec.rb
@@ -3,17 +3,13 @@ require 'spec_helper'
 describe EventInstancesHelper, type: :helper do
   it 'generates a unique id for a hangout event' do
     user = FactoryGirl.build_stubbed(:user, id: '45')
-    project = FactoryGirl.build_stubbed(:project, id: '85')
 
-    allow(Time).to receive(:now).and_return(Time.parse('02/03/2014 10:05:05 UTC'))
-
-    expect(generate_event_instance_id(user, '85')).to eq('45851393754705')
+    expect(generate_event_instance_id(user, '85')).to eq('4585')
   end
 
   it 'generates an id if project is nil' do
     user = FactoryGirl.build_stubbed(:user, id: '45')
-    allow(Time).to receive(:now).and_return(Time.parse('02/03/2014 10:05:05 UTC'))
 
-    expect(generate_event_instance_id(user)).to eq('45001393754705')
+    expect(generate_event_instance_id(user)).to eq('4500')
   end
 end


### PR DESCRIPTION
* remove time to EventInstance id, it will be set at Hangout app
* update test of helper generate_event_instance_id