### PR TITLE
Allow user to create event in local timezone (#1079) (#1081)

### DIFF
--- a/app/assets/javascripts/select_time_zone_and_update_date_and_time.js
+++ b/app/assets/javascripts/select_time_zone_and_update_date_and_time.js
@@ -1,12 +1,15 @@
 jQuery.fn.selectTimeZoneAndUpdateDateAndTime = function () {
 
     var setLocalDateAndTime = function () {
-        var date = $('#start_date').val();
+        var next_date = $('#next_date').val();
+        var start_date = $('#start_date').val();
         var time = $('#start_time').val();
-        var normalized_date_time = moment.utc(date + " " + time, "YYYY-MM-DD hh:mm a");
-        var local_date_time = normalized_date_time.tz(jstz.determine().name());
-        $('#start_date').val(local_date_time.format("YYYY-MM-DD"));
-        $('#start_time').val(local_date_time.format("hh:mm A"));
+        var normalized_next_date_time = moment.utc(next_date + " " + time, "YYYY-MM-DD hh:mm a");
+        var normalized_start_date_time = moment.utc(start_date + " " + time, "YYYY-MM-DD hh:mm a");
+        var local_next_date_time = normalized_next_date_time.tz(jstz.determine().name());
+        var local_start_date_time = normalized_start_date_time.tz(jstz.determine().name());
+        $('#start_date').val(local_start_date_time.format("YYYY-MM-DD"));
+        $('#start_time').val(local_next_date_time.format("hh:mm A"));
     };
 
     setLocalDateAndTime();

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -69,10 +69,19 @@ class EventsController < ApplicationController
     event_params
   end
 
+  # next_date and start_date are in the same dst or non-dst
+  # next_date in dst and start_date in non-dst ==> get an hour back
+  # next_date in non-dst and start_date in dst ==> ???
+
   def create_start_date_time(event_params)
     return unless date_and_time_present?
     tz = TZInfo::Timezone.get(params['start_time_tz'])
-    event_params[:start_datetime] = tz.local_to_utc(DateTime.parse(params['start_date']+ ' ' + params['start_time']))
+    event_params[:start_datetime] = next_date_offset(tz).to_utc(DateTime.parse(params['start_date']+ ' ' + params['start_time']))
+  end
+
+  def next_date_offset(tz)
+    next_date_time = DateTime.parse(params['next_date'] + ' ' + params['start_time'])
+    tz.period_for_utc(next_date_time).offset
   end
 
   def date_and_time_present?

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -26,7 +26,9 @@
       <div class="form-group event_date">
         <%= label_tag 'start_date', 'Start Date', class: 'control-label' %>
         <%= text_field_tag 'start_date', format_datepicker(start_date), style: 'width:auto;', class: 'form-control datepicker' %>
+        <%= hidden_field_tag 'next_date', begin format_datepicker(@event.next_event_occurrence_with_time()[:time]) rescue '' end %>
       </div>
+
       <div class="form-group event_time">
         <%= label_tag 'start_time', 'Start Time', class: 'control-label' %>
         <%= text_field_tag 'start_time', format_timepicker(start_time), style: 'width:auto;', class: 'form-control timepicker' %>

--- a/features/events/create_events.feature
+++ b/features/events/create_events.feature
@@ -86,3 +86,15 @@ Feature: Events
     When I dropdown the "Events" menu
     And I click "Upcoming events"
     And I should see multiple "Standup" events
+
+
+
+# dimensions
+
+#     * start date (future, past)
+#     * operation (creating, editing)
+#     * timezone user is in (one of many - choose representative set)
+#     * daylight savings difference between next event and start event (true, false)
+#     * repeating event (true, false)
+#       * repeated event already terminated
+#     * will combination of timezone and date lead to change in date field (true, false)

--- a/features/events/edit_future_event.feature
+++ b/features/events/edit_future_event.feature
@@ -1,0 +1,48 @@
+@javascript @vcr
+Feature: Editing an event with a start date in the future
+  As a site user
+  In order to be able to update planned activities
+  I would like to edit event details
+
+  Background:
+    Given the date is "2014/02/01 09:15:00 UTC"
+    And I am logged in
+    And I am on Events index page
+    When I click "New Event"
+    And I select "Repeats" to "weekly"
+    And I check "Monday"
+    And I check "Thursday"
+    Given I fill in event field:
+      | name        | value         |
+      | Name        | Daily Standup |
+      | Start Date  | 2014-02-04    |
+      | Start Time  | 09:00         |
+      | Description | we stand up   |
+      | End Date    | 2014-03-04    |
+    Then the event is set to end sometime
+    And I click on the "repeat_ends_on" div
+    And I click the "Save" button
+    And I am on Events index page
+
+  Scenario: Check that edit page reflects initial settings
+    And I visit the edit page for the event named "Daily Standup"
+    Then the "Repeat ends" selector should be set to "on"
+
+  Scenario: Edit an existing event to never end
+    And I visit the edit page for the event named "Daily Standup"
+    And I select "Repeat ends" to "never"
+    And I click the "Save" button
+    Then I should be on the event "Show" page for "Daily Standup"
+    And I should see "09:00-09:30 (UTC)"
+    And I visit the edit page for the event named "Daily Standup"
+    Then the "Repeat ends" selector should be set to "never"
+
+  Scenario: Edit an existing event to be in a different time zone
+    And I visit the edit page for the event named "Daily Standup"
+    And I select "Hawaii" from the time zone dropdown
+    And I click the "Save" button
+    Then I should be on the event "Show" page for "Daily Standup"
+    And I should see "19:00-19:30 (UTC)"
+    And I visit the edit page for the event named "Daily Standup"
+    Then the start time is "07:00 PM"
+

--- a/features/events/edit_past_event.feature
+++ b/features/events/edit_past_event.feature
@@ -1,11 +1,11 @@
 @javascript @vcr
-Feature: Events
+Feature: Editing an event with start date in the past
   As a site user
-  In order to be able to update planned activities
-  I would like to edit events
+  In order to be able to update existing activities
+  I would like to edit event details
 
   Background:
-    Given the date is "2014/02/01 09:15:00 UTC"
+    Given the date is "2016/02/01 09:15:00 UTC"
     And I am logged in
     And I am on Events index page
     When I click "New Event"
@@ -18,7 +18,7 @@ Feature: Events
       | Start Date  | 2014-02-04    |
       | Start Time  | 09:00         |
       | Description | we stand up   |
-      | End Date    | 2014-03-04    |
+      | End Date    | 2016-03-04    |
     Then the event is set to end sometime
     And I click on the "repeat_ends_on" div
     And I click the "Save" button
@@ -46,3 +46,27 @@ Feature: Events
     And I visit the edit page for the event named "Daily Standup"
     Then the start time is "07:00 PM"
 
+  Scenario: User in non-UTC timezone edits an existing event, with no
+    And I visit the edit page for the event named "Daily Standup"
+    And the user is in "US/Hawaii" timezone
+    Then the start time is "11:00 PM"
+    Then the start date is "2014-02-03"
+    And I click the "Save" button
+    Then I should be on the event "Show" page for "Daily Standup"
+    And I should see "09:00-09:30 (UTC)"
+    And I visit the edit page for the event named "Daily Standup"
+    Then the start time is "09:00 AM"
+    And the start date is "2014-02-04"
+
+  Scenario: User in non-UTC timezone Edits an existing event, with no changes, and daylight savings involved
+    Given the date is "2015/06/14 09:15:00 UTC"
+    And I visit the edit page for the event named "Daily Standup"
+    And the user is in "Europe/London" timezone
+    Then the start time is "10:00 AM"
+    Then the start date is "2014-02-04"
+    And I click the "Save" button
+    Then I should be on the event "Show" page for "Daily Standup"
+    And I should see "09:00-09:30 (UTC)"
+    And I visit the edit page for the event named "Daily Standup"
+    Then the start time is "09:00 AM"
+    And the start date is "2014-02-04"

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -142,3 +142,12 @@ end
 And(/^the start time is "([^"]*)"$/) do |start_time|
   expect(find("#start_time").value).to eq start_time
 end
+
+And(/^the start date is "([^"]*)"$/) do |start_date|
+  expect(find("#start_date").value).to eq start_date
+end
+
+Then(/^the user is in "([^"]*)" timezone$/) do |zone|
+  page.execute_script("jstz.determine = function(){ return { name: function(){ return '#{zone}' } } };")
+  page.execute_script('handleUserTimeZone();')
+end

--- a/spec/javascripts/select_time_zone_and_update_date_and_time_spec.js
+++ b/spec/javascripts/select_time_zone_and_update_date_and_time_spec.js
@@ -3,6 +3,7 @@ describe('selectTimeZoneAndUpdateDateAndTime', function () {
     beforeEach(function () {
         setFixtures('<div>'+
             '<input type="text" name="start_date" id="start_date" value="2016-05-27" style="width:auto;" class="form-control datepicker">'+
+            '<input type="hidden" name="next_date" id="next_date" value="2016-05-27" style="width:auto;" class="form-control datepicker">'+
             '</div>'+
             '<div>'+
             '<input type="text" name="start_time" id="start_time" value="10:27 pm" style="width:auto;" class="form-control timepicker">'+


### PR DESCRIPTION
* adds next time to event form as hidden field and uses in javascript, but introduces time progression bug

* adjusts event controller to take account of next event date when working out timezone during event save

* fixes the jasmine test for the timezone selector by adjusting the date

* adjusts timezone selector to use start date when updating start date

* adds acceptance tests of timezone edits

* extracting method for code climate

* quick fix to silly variable mistake