### PR TITLE
1064 - instructions to signup with github public email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,7 +151,7 @@ class User < ActiveRecord::Base
     if email.blank? and not @omniauth_provider.nil?
       errors.delete(:password)
       errors.delete(:email)
-      errors.add(:base, "Your #{@omniauth_provider.capitalize} account needs to have a public email address for sign up")
+      errors.add(:base,  I18n.t('error_messages.public_email', provider: @omniauth_provider.capitalize))
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,5 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  error_messages:
+    public_email: "Your %{provider} account needs to have a public email address for sign up. <a href='https://github.com/AgileVentures/WebsiteOne/tree/develop/docs/solutions_for_signup_issues.md'>Click here for instructions</a>."

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -97,6 +97,10 @@ When /^I filter users for "(.*?)"$/ do |first_name|
   #click_link_or_button :UsersFilterSubmit
 end
 
+When /^I sign up with GitHub$/ do
+  click_link_or_button 'GitHub'
+end
+
 ### THEN ###
 Then /^I should be signed in$/ do
   expect(page).to have_content "Log out"
@@ -150,6 +154,10 @@ Then /^I should (not |)see my name$/ do |should|
   else
     expect(page).to have_content @user.presenter.display_name
   end
+end
+
+Then /^I should see link for instructions to sign up$/ do
+  expect(page).to have_link('Click here for instructions', href: /github.com\/AgileVentures\/WebsiteOne\/tree\/develop\/docs\/solutions_for_signup_issues.md/)
 end
 
 Given /^the following users exist$/ do |table|

--- a/features/users/create_users.feature
+++ b/features/users/create_users.feature
@@ -46,10 +46,8 @@ Feature: As a developer
   @omniauth-without-email
   Scenario: User signs up with a GitHub account having no public email (sad path)
     Given I am on the "registration" page
-    When I click "GitHub"
-    Then I should see "Your Github account needs to have a public email address for sign up"
-    Then I should see the "github-alt" icon
-    And I should not see "Password can't be blank"
+    When I sign up with GitHub
+    Then I should see link for instructions to sign up
 
   #removed g+ signup while it appearas broken
   #@omniauth-without-email


### PR DESCRIPTION
Provides link to GitHub page (instructions to sign up) in public email error message