### PR TITLE
error message for failed github unlinking

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -33,7 +33,7 @@ class AuthenticationsController < ApplicationController
     if @authentication
       if current_user.authentications.count == 1 and current_user.encrypted_password.blank?
         # Bryan: TESTED
-        flash[:alert] = 'Bad idea!'
+        flash[:alert] = 'Failed to unlink GitHub. Please use another provider for login or reset password.'
       elsif @authentication.destroy
         flash[:notice] = 'Successfully removed profile.'
       else

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -48,7 +48,7 @@ describe AuthenticationsController do
       expect(@auths).to receive(:count).and_return 1
       expect(@user).to receive(:encrypted_password).and_return nil
       get :destroy, id: 1
-      expect(flash[:alert]).to eq 'Bad idea!'
+      expect(flash[:alert]).to eq 'Failed to unlink GitHub. Please use another provider for login or reset password.'
     end
   end
 

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -57,7 +57,7 @@ describe 'OmniAuth authentication' do
               click_link "Remove #{name}"
             }.to change(User, :count).by(0)
           }.to change(Authentication, :count).by(0)
-          expect(page).to have_content 'Bad idea!'
+          expect(page).to have_content 'Failed to unlink GitHub. Please use another provider for login or reset password.'
         end
       end
     end


### PR DESCRIPTION
Adds more feedback in error message. 

This separates out the message change for issue #1230 and should be merged first before #1130 which focuses on resolving github unlinking.