### PR TITLE
1271 Use free tier dyno for review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,6 +44,12 @@
     "sendgrid",
     "heroku-postgresql"
   ],
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "Free"
+    }
+  },
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-ruby"


### PR DESCRIPTION
Configure heroku app.json to use Free dyno tier for review app

Addresses: https://github.com/AgileVentures/WebsiteOne/issues/1271