### PR TITLE
1267 Edit stripe locale config

### DIFF
--- a/app/views/charges/edit.html.erb
+++ b/app/views/charges/edit.html.erb
@@ -6,6 +6,6 @@
   data-panel-label="Update Card Details"
   data-label="Update Card Details"
   data-allow-remember-me=false
-  data-locale="auto">
+  data-locale="en-US">
   </script>
 <% end %>

--- a/app/views/charges/premium.html.erb
+++ b/app/views/charges/premium.html.erb
@@ -21,7 +21,7 @@
             data-description="A month's subscription"
             data-amount="1000"
             data-currency="GBP"
-            data-locale="auto"
+            data-locale="en-US"
             data-name="Premium Membership"
             data-label="Sign Me Up For Premium!"></script>
 


### PR DESCRIPTION
Addresses: https://github.com/AgileVentures/WebsiteOne/issues/1267

I changed locale setting of stripe from **auto** to **en-US**. So developers can work on project without need of tweaking cassette files and also to prevent displaying the popup in different languages for users. 
