### PR TITLE
1324 hire me button removed for the logged in user 

### DIFF
--- a/app/views/users/profile/_summary.html.erb
+++ b/app/views/users/profile/_summary.html.erb
@@ -39,7 +39,7 @@
         </li>
     <% end %>
 
-    <% if presenter.display_hire_me %>
+    <% if presenter.display_hire_me && current_user != presenter.user %>
         <li>
           <%= link_to 'Hire me', user_path(presenter.user),
                       {remote: true, class: 'user-profile-btn',

--- a/features/users/profile_privacy.feature
+++ b/features/users/profile_privacy.feature
@@ -59,6 +59,7 @@ Feature: As a site user
     And "Display email" should not be checked
     When I set my email to be public
     And I click "Update"
+    And I am on my "Profile" page
     Then I should see my email
 
   @javascript
@@ -74,19 +75,20 @@ Feature: As a site user
 
   Scenario: Hire Me button should be private by default
     Given I am logged in
+    And I sign out
     And I am on my "Profile" page
     Then I should not see button "Hire me"
 
-  @javascript
   Scenario: Should be able to make my Hire Me button public
     Given I am logged in
     And I am on my "Edit Profile" page
     And "Display Hire Me" should not be checked
     When I set my Hire Me to be public
     And I click "Update"
+    And I sign out
+    And I am on my "Profile" page
     Then I should see button "Hire me"
 
-  @javascript
   Scenario: Should be able to make my Hire Me button private again
     Given I am logged in
     And My hire me was set to public
@@ -94,7 +96,16 @@ Feature: As a site user
     Then "Display Hire Me" should be checked
     When I set my Hire Me to be private
     And I click "Update"
+    And I sign out
     And I am on my "Profile" page
+    Then I should not see button "Hire me"
+
+  Scenario: Should not be able to see Hire Me button when logged in
+    Given I am logged in
+    And I am on my "Edit Profile" page
+    And "Display Hire Me" should not be checked
+    When I set my Hire Me to be public
+    And I click "Update"
     Then I should not see button "Hire me"
 
     # Bryan: To be added back later in another story


### PR DESCRIPTION
Fixes #1324 
This change removes the "Hire me" button from the logged in user's profile page.  The button is still visible to anyone except for the current user.

Removed ```@javascript``` from the cucumber tests related to this change.  With it in there, the ```sign out``` step fails with the error:  
```
undefined method `submit' for #<Capybara::Poltergeist::Driver:0x007f8f12ec4110> (NoMethodError)
      ./features/step_definitions/user_steps.rb:49:in `/^I sign out$/'
      features/users/profile_privacy.feature:102:in `And I sign out'
```

This is my first pull request on the project.  Any feedback or changes needed are welcome :)
