### PR TITLE
Autolink urls in event descriptions on event show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'acts_as_votable', '~> 0.10.0' #Allows WSO to track member's votes on votabl
 gem 'utf8-cleaner'
 gem 'public_activity' #Create activity feed
 gem 'nokogiri', '~> 1.6.7.2'
+gem 'rails_autolink', '~>1.1.6'
 
 gem 'yui-compressor'
 gem 'compass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,6 +420,8 @@ GEM
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.5)
     railties (4.2.6)
@@ -658,6 +660,7 @@ DEPENDENCIES
   railroady
   rails (= 4.2.6)
   rails_12factor
+  rails_autolink (~> 1.1.6)
   redcarpet
   rspec
   rspec-activemodel-mocks

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,7 +2,7 @@
   <div class="col-xs-12">
     <h1><%= @event.name %></h1>
 
-    <p><%= @event.description %></p>
+    <p><%= auto_link(@event.description) %></p>
   </div>
 </div>
 

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'events/show', type: :view do
   before(:each) do
     @event = FactoryGirl.build_stubbed(Event, name: 'EuroAsia Scrum',
                                        category: 'Scrum',
-                                       description: 'EuroAsia Scrum and Pair hookup',
+                                       description: 'EuroAsia Scrum and Pair hookup http://lin.ky/',
                                        time_zone: 'Eastern Time (US & Canada)',
                                        project_id: 1)
 
@@ -24,8 +24,9 @@ describe 'events/show', type: :view do
     expect(rendered).to have_text(@event.name)
   end
 
-  it 'should render the event description' do
-    expect(rendered).to have_text(@event.description)
+  it 'should render the event description, with links hyperlinked' do
+    expect(rendered).to have_link('http://lin.ky')
+    expect(rendered).to have_content('EuroAsia Scrum and Pair hookup http://lin.ky')
   end
 
   describe 'Hangouts' do


### PR DESCRIPTION
Adds the autolink gem, and uses it on the Event#show page re this issue: Fixes https://github.com/AgileVentures/WebsiteOne/issues/769