### PR TITLE
FIX email link goes to 404 error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ WebsiteOne::Application.routes.draw do
   resources :newsletters
 
   match '/subscriptions/upgrade' => 'subscriptions#upgrade', :via => [:put]
-  resources :subscriptions
+  resources :subscriptions, only: [:create, :edit, :update, :new]
 
   devise_for :users, :controllers => {:registrations => 'registrations'}
   resources :users, :only => [:index, :show], :format => false do

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe SubscriptionsController, :type => :controller do
+
+  describe "Attempt to get individual subscription/upgrade" do
+    it "raises URL Generation error" do
+        expect { get "/subscriptions/upgrade" }.to raise_error(ActionController::UrlGenerationError)
+    end
+  end
+
+end


### PR DESCRIPTION
#### Description

I fixed this error #1495 by replacing the wrong link with mailto

#### Motivation and Context
The wrong link goes to 404 page

#### How Has This Been Tested?
Click in the email address in user profile

#### Types of changes
in views/users/profile on line 34 change:
`<%= presenter.email_link %>`
to:
`<%= mail_to presenter.email %>`
