### PR TITLE
WIP - 1561 change g+ button to google

### DIFF
--- a/app/assets/stylesheets/global/social.scss
+++ b/app/assets/stylesheets/global/social.scss
@@ -162,14 +162,14 @@ $fa-custom-icon-size: 1.1em;
 }
 
 .btn-gplus {
-    color: #fff;
-    background-color: #dd4b39;
+    color: white;
+    background-color: #4285f4;
     border-color: rgba(0, 0, 0, 0.2)
 }
 
 .btn-gplus:hover, .btn-gplus:focus, .btn-gplus:active, .btn-gplus.active, .open .dropdown-toggle.btn-gplus {
-    color: #fff;
-    background-color: #ca3523;
+    color: white;
+    background-color: #356ac3;
     border-color: rgba(0, 0, 0, 0.2)
 }
 
@@ -178,6 +178,6 @@ $fa-custom-icon-size: 1.1em;
 }
 
 .btn-gplus.disabled, .btn-gplus[disabled], fieldset[disabled] .btn-gplus, .btn-gplus.disabled:hover, .btn-gplus[disabled]:hover, fieldset[disabled] .btn-gplus:hover, .btn-gplus.disabled:focus, .btn-gplus[disabled]:focus, fieldset[disabled] .btn-gplus:focus, .btn-gplus.disabled:active, .btn-gplus[disabled]:active, fieldset[disabled] .btn-gplus:active, .btn-gplus.disabled.active, .btn-gplus[disabled].active, fieldset[disabled] .btn-gplus.active {
-    background-color: #dd4b39;
+    background-color: #4285f4;
     border-color: rgba(0, 0, 0, 0.2)
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,13 +53,13 @@ module ApplicationHelper
   def social_button(provider, options={})
     provider = provider.downcase
     display_name = {
-        'github' => 'GitHub',
-        'gplus' => 'Google+'
+        'github' => 'with GitHub',
+        'gplus' => 'with Google'
     }
 
     fa_icon = {
         'github' => 'github-alt',
-        'gplus' => 'google-plus'
+        'gplus' => 'google'
     }
 
     options[:url] = root_path unless options[:url].present?


### PR DESCRIPTION
#### Description
I updated the social_button method in application_helper.rb so that upon sign in and sign-up the user wouldn't be confused as to whether they will sign-in with their google account as opposed to their google plus account.

#### Motivation and Context

Users shouldn't be confused anymore that we're logging them in with their google credentials.

#### Concerns

- I used the font-awesome google icon for consistency. As a result the bar doesn't look like the original design proposed by Federico: 

![image](https://cloud.githubusercontent.com/assets/20600943/23664605/ebb59d32-034d-11e7-93bd-9cc6725937d4.png)

- The provider name associated is still 'gplus' which is not explicit if we're talking about the google account.

#### How Has This Been Tested?

No new test added.
All previous tests working fine.

#### Screenshots (if appropriate):

Current look:

![image](https://cloud.githubusercontent.com/assets/20600943/23664347/3e4b0baa-034d-11e7-905d-bb9d7ff7d231.png)


New look:

![image](https://cloud.githubusercontent.com/assets/20600943/23664317/2a782676-034d-11e7-84b8-91b56d324c42.png)


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.