### PR TITLE
1577-fixing-broken-links-in-contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Note that you should be re-syncing daily (even hourly at very active times) on y
 feature/bugfix branch to ensure that you are always building on top of very latest develop code.
 
 ### Pull Requests: naming, syncing, size
-Here is [how to create and submit a pull requests](https://help.github.com/articles/creating-a-pull-request/).
+Here is [how to create and submit a pull requests](https://github.com/AgileVentures/WebsiteOne/blob/develop/docs/how_to_submit_a_pull_request_on_github.md).
 
 Every pull request should refer to a corresponding GitHub issue, and when you create feature/bug-fix branches please include the id of the relevant issue, e.g.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,54 +1,54 @@
 # Contributing to WebSiteOne (WSO)
 
-This describes how to contribute to WebSiteOne:  the tools we use to track and 
+This describes how to contribute to WebSiteOne:  the tools we use to track and
 coordinate the work that is happening and that needs to happen. This also describes the
 *workflow* -- the processes and sequences for getting contributions merged into the project in an organized and coherent way.
 
 First be sure that you've set up your development environment following all the steps
  in **[Setting Up for Development on WebSiteOne _(Project Set Up)_](https://github.com/AgileVentures/WebsiteOne/blob/develop/docs/project_setup.md)**
 
- 
+
 We use [Waffle](https://waffle.io/AgileVentures/WebsiteOne) to manage our work on features, chores and bugfixes.
 
 We keep our code on [GitHub](http://github.com) and use [git](https://git-scm.com) for version control.
 
-   
 
- 
+
+
 ## General Steps
 To get involved please follow these steps:
 
 ####1. Get the system working on your development environment:
 
    1. [install WSO on your dev environment (laptop or c9)](https://github.com/AgileVentures/WebsiteOne/blob/develop/docs/project_setup.md)
-   
+
    2. get tests passing
-   
+
    3. check that the site can be run manually (locally)
-    
+
    4. (optional) deploy to a remote (e.g. Heroku, drie etc.) and ensure it runs there
-   
+
 ####2. Look at what needs to be done on GitHub
- 
+
 * review [open PRs](https://github.com/AgileVentures/WebsiteOne/pulls) on GitHub - leave comments or collaborate if interested
 
- 
-####3. Look at what needs to be done on [our waffle project board:](https://github.com/AgileVentures/WebsiteOne/pulls)  
+
+####3. Look at what needs to be done on [our waffle project board:](https://waffle.io/AgileVentures/WebsiteOne)
 
   1. look through **[ready](https://waffle.io/AgileVentures/WebsiteOne)** column - feel free to start work, but always interested to hear chat in slack, scrum wherever
 
   3. look through **[estimated](https://waffle.io/AgileVentures/WebsiteOne)** column - feel free to ask about priority, as these are not prioritised
 
   4. look at **[backlog](https://waffle.io/AgileVentures/WebsiteOne)** - if there is an interesting ticket get it voted on in a scrum or do an [ASYNC Vote](https://github.com/AgileVentures/AgileVentures/blob/master/ASYNC_VOTING.md) in Slack
-  
+
   Items need to be voted on before work can start.  Voting happens in scrums or using the [ASYNC Voting bot](https://github.com/AgileVentures/AgileVentures/blob/master/ASYNC_VOTING.md) in the Slack channel.
-  
+
 
 
 ## git and GitHub
 Our **default working branch is `develop`**.  We do work by creating branches off `develop` for new features and bugfixes.
-  
-Any *feature* should include appropriate Cucumber acceptance tests and RSpec unit tests.  We try to avoid view and controller specs, and focus purely on unit tests at the model and service level where possible.  
+
+Any *feature* should include appropriate Cucumber acceptance tests and RSpec unit tests.  We try to avoid view and controller specs, and focus purely on unit tests at the model and service level where possible.
 
 A *bugfix* may include an acceptance test depending on where the bug occurred, but fixing a bug should start with the creation of a test that replicates the bug, so that any bugfix submission will include an appropriate test as well as the fix itself.
 
@@ -58,11 +58,11 @@ Each developer will usually work with a [fork](https://help.github.com/articles/
 git pull upstream develop
 ```
 
-Note that you should be re-syncing daily (even hourly at very active times) on your 
+Note that you should be re-syncing daily (even hourly at very active times) on your
 feature/bugfix branch to ensure that you are always building on top of very latest develop code.
 
 ### Pull Requests: naming, syncing, size
-Here is [how to create and submit a pull requests](how_to_submit_a_pull_request_on_github.md).
+Here is [how to create and submit a pull requests](https://help.github.com/articles/creating-a-pull-request/).
 
 Every pull request should refer to a corresponding GitHub issue, and when you create feature/bug-fix branches please include the id of the relevant issue, e.g.
 


### PR DESCRIPTION
I fixed two links in CONTRIBUTING.md

#### Description

#### Motivation and Context
When clicking this hyperlink:

![image](https://cloud.githubusercontent.com/assets/20600943/23899954/3a9e85ec-08af-11e7-8f7b-026f19ade600.png)

We are currently redirected to: https://github.com/AgileVentures/WebsiteOne/pulls

When clicking this hyperlink:

![image](https://cloud.githubusercontent.com/assets/20600943/23900013/7327196a-08af-11e7-8e3f-a046ea53a556.png)

We currently get a 404.

I have replaced both links with more appropriate redirections.

#### How Has This Been Tested?
No new tests have been added. All current tests pass

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
