### PR TITLE
Fix video link from http to https

### DIFF
--- a/app/presenters/event_instance_presenter.rb
+++ b/app/presenters/event_instance_presenter.rb
@@ -31,7 +31,7 @@ class EventInstancePresenter < BasePresenter
 
   def video_url
     if id = event_instance.yt_video_id
-      "http://www.youtube.com/watch?v=#{id}&feature=youtube_gdata".html_safe
+      "https://www.youtube.com/watch?v=#{id}&feature=youtube_gdata".html_safe
     else
       '#'
     end
@@ -48,7 +48,7 @@ class EventInstancePresenter < BasePresenter
 
   def video_embed_link
     if yt_video_id.present?
-      "http://www.youtube.com/embed/#{yt_video_id}?enablejsapi=1"
+      "https://www.youtube.com/embed/#{yt_video_id}?enablejsapi=1"
     end
   end
 

--- a/features/hangouts/hangout.feature
+++ b/features/hangouts/hangout.feature
@@ -91,7 +91,7 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
       | WebsiteOne   |
     And I should see the avatar for "Alice"
     And I should see link "Join" with "http://hangout.test"
-    And I should see link "Watch" with "http://www.youtube.com/watch?v=QWERT55&feature=youtube_gdata"
+    And I should see link "Watch" with "https://www.youtube.com/watch?v=QWERT55&feature=youtube_gdata"
 
     And I should see:
       | 11:11       |
@@ -100,7 +100,7 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
       | Autograders |
     And I should see the avatar for "Bob"
     And I should see link "Join" with "http://hangout.session"
-    And I should see link "Watch" with "http://www.youtube.com/watch?v=TGI345&feature=youtube_gdata"
+    And I should see link "Watch" with "https://www.youtube.com/watch?v=TGI345&feature=youtube_gdata"
 
   Scenario: Display live sessions - extra info
     Given the date is "2014/02/01 11:10:00 UTC"

--- a/spec/presenters/event_instance_presenter_spec.rb
+++ b/spec/presenters/event_instance_presenter_spec.rb
@@ -45,7 +45,7 @@ describe EventInstancePresenter do
     end
 
     it 'returns video url' do
-      expect(presenter.video_url).to eq("http://www.youtube.com/watch?v=#{presenter.yt_video_id}&feature=youtube_gdata")
+      expect(presenter.video_url).to eq("https://www.youtube.com/watch?v=#{presenter.yt_video_id}&feature=youtube_gdata")
     end
 
     it 'returns a link to video' do
@@ -56,7 +56,7 @@ describe EventInstancePresenter do
     end
 
     it 'returns a link to youtube player' do
-      link = "http://www.youtube.com/embed/#{presenter.yt_video_id}?enablejsapi=1"
+      link = "https://www.youtube.com/embed/#{presenter.yt_video_id}?enablejsapi=1"
       expect(presenter.video_embed_link).to eq(link)
     end
   end

--- a/spec/views/event_instances/index.html.erb_spec.rb
+++ b/spec/views/event_instances/index.html.erb_spec.rb
@@ -32,7 +32,7 @@ describe 'event_instances/index', type: :view do
     expect(rendered).to have_text(hangout.title)
     expect(rendered).to have_link(hangout.project.title, project_path(hangout.project))
     expect(rendered).to have_link('Join', href: hangout.hangout_url)
-    expect(rendered).to have_link('Watch', href: "http://www.youtube.com/watch?v=#{hangout.yt_video_id}&feature=youtube_gdata")
+    expect(rendered).to have_link('Watch', href: "https://www.youtube.com/watch?v=#{hangout.yt_video_id}&feature=youtube_gdata")
   end
 
   it 'disables the join button if hangout is not live' do

--- a/spec/views/projects/show.html.erb_spec.rb
+++ b/spec/views/projects/show.html.erb_spec.rb
@@ -187,7 +187,7 @@ describe 'projects/show.html.erb', type: :view do
     it 'renders list of youtube links and published dates if user has videos' do
       render
       event_instances.each do |video|
-        href = "http://www.youtube.com/watch?v=#{video.yt_video_id}&feature=youtube_gdata"
+        href = "https://www.youtube.com/watch?v=#{video.yt_video_id}&feature=youtube_gdata"
         expect(rendered).to have_link(video.title, :href => href)
         expect(rendered).to have_text(video.user.first_name)
         expect(rendered).to have_text(video.created_at.strftime('%H:%M %d/%m'))

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -126,7 +126,7 @@ describe 'users/show.html.erb' do
   it 'renders list of youtube links and published dates if user has videos' do
     render
     @event_instances.each do |video|
-      href = "http://www.youtube.com/watch?v=#{video.yt_video_id}&feature=youtube_gdata"
+      href = "https://www.youtube.com/watch?v=#{video.yt_video_id}&feature=youtube_gdata"
       expect(rendered).to have_link(video.title, :href => href)
       expect(rendered).to have_text(video.created_at.strftime('%H:%M %d/%m'))
     end


### PR DESCRIPTION
fixes #1655 

Tested manually by comparing /projects/websiteone#video on live site to local.
