### PR TITLE
SPIKE edit youtube link for EventInstance

### DIFF
--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -36,12 +36,13 @@ class EventInstancesController < ApplicationController
 
   def update_link
     @event_instance = EventInstance.find(params[:id])
-    if @event_instance.update_attributes(yt_video_id: YouTubeRails.extract_video_id(event_instance_params[:yt_video_id]) )
+    youtube_id = YouTubeRails.extract_video_id(event_instance_params[:yt_video_id])
+    if youtube_id && @event_instance.update_attributes(yt_video_id: youtube_id )
       flash[:notice] = "Link Updated"
       redirect_to edit_event_instance_path(@event_instance)
     else
       flash[:alert] = "Error.  Please Try again"
-      render edit_event_instance_path(@event_instance)
+      redirect_to edit_event_instance_path(@event_instance)
     end
   end
 

--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -1,6 +1,7 @@
 class EventInstancesController < ApplicationController
   skip_before_filter :verify_authenticity_token
-  before_filter :cors_preflight_check, except: [:index]
+  before_filter :cors_preflight_check, except: [:index, :edit, :update_link]
+  # before_action :authenticate_user!, only: [:edit, :update_link]
 
   def update
     event_instance = EventInstance.find_or_create_by(uid: params[:id])
@@ -29,7 +30,26 @@ class EventInstancesController < ApplicationController
     @event_instances = relation.paginate(:page => params[:page])
   end
 
+  def edit
+    @event_instance = EventInstance.find(params[:id])
+  end
+
+  def update_link
+    @event_instance = EventInstance.find(params[:id])
+    if @event_instance.update_attributes(yt_video_id: YouTubeRails.extract_video_id(event_instance_params[:yt_video_id]) )
+      flash[:notice] = "Link Updated"
+      redirect_to edit_event_instance_path(@event_instance)
+    else
+      flash[:alert] = "Error.  Please Try again"
+      render edit_event_instance_path(@event_instance)
+    end
+  end
+
   private
+
+  def event_instance_params
+    params.require(:event_instance).permit(:yt_video_id)
+  end
 
   def cors_preflight_check
     head :bad_request and return unless (allowed? || local_request?)

--- a/app/views/event_instances/edit.html.erb
+++ b/app/views/event_instances/edit.html.erb
@@ -1,5 +1,7 @@
-<%= form_for @event_instance, :url => "/event_instances/#{@event_instance.id}" do |f| %>
-  <%= f.label "Youtube Link" %>
-  <%= f.text_field :yt_video_id, :value => "http://youtube.com/watch?v#{@event_instance.yt_video_id}" %>
+<%= form_for @event_instance, :url => "/event_instances/#{@event_instance.id}", html: {class: 'form-vertical', id: 'event-form'} do |f| %>
+  <div class='form-group'>
+  <%= f.label "Youtube Video Link", class: 'control-label' %>
+  <%= f.text_field :yt_video_id,  :value => "http://youtube.com/watch?v=#{@event_instance.yt_video_id}", class: 'form-control' %>
+  </div>
   <%= f.submit %>
 <% end %>

--- a/app/views/event_instances/edit.html.erb
+++ b/app/views/event_instances/edit.html.erb
@@ -1,0 +1,5 @@
+<%= form_for @event_instance, :url => "/event_instances/#{@event_instance.id}" do |f| %>
+  <%= f.label "Youtube Link" %>
+  <%= f.text_field :yt_video_id, :value => "http://youtube.com/watch?v#{@event_instance.yt_video_id}" %>
+  <%= f.submit %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ WebsiteOne::Application.routes.draw do
 
   root 'visitors#index'
 
+
+
   get '/.well-known/acme-challenge/:id' => 'static_pages#letsencrypt'
 
   resources :activities
@@ -30,6 +32,9 @@ WebsiteOne::Application.routes.draw do
 
   match '/hangouts/:id' => 'event_instances#update', :via => [:put, :options], as: 'hangout'
   match '/hangouts' => 'event_instances#index', :via => [:get], as: 'hangouts'
+
+  resources :event_instances, :only => [:edit]
+  patch '/event_instances/:id', to: 'event_instances#update_link'
 
   resources :projects, :format => false do
     member do
@@ -82,7 +87,3 @@ WebsiteOne::Application.routes.draw do
   get '*id', to: 'static_pages#show', as: 'static_page', :format => false
 
 end
-
-
-
-


### PR DESCRIPTION
I want to see if this is the desired path before I go too far along.  Appropriate tests, links to the edit page, and authorization will be added before submitting this to merge.    

#### Description
Spike for issue #1682 .  Adds the ability to edit a youtube link for an EventInstance.  

#### Questions
* Are videos hosted in places other than youtube?  
  * Currently this path would only be for youtube videos.  The youtube video ID is what is persisted so I am sticking to that in order to not break things elseware.  
* Is there currently any role based authorization?
  * One of the things mentioned in the issue was to have the link editable by an admin.  At first glance,
  I didn't see any roles for users.  I think it would make sense to have that.  I would also have the link 
 modifiable by the creator of the associated event.  



