### PR TITLE
Add Press-Kit link to footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -8,6 +8,7 @@
           <li><%= link_to 'Getting Started', static_page_path('Getting Started') %></li>
           <li><%= link_to 'Dashboard', dashboard_path %></li>
           <li><%= link_to 'Blog', 'http://nonprofits.agileventures.org/blog/' %> </li>
+          <li><%= link_to 'Press Kit', 'http://www.agileventures.org/press-kit' %></li>
         </ul>
       </div>
 

--- a/features/basic_layout.feature
+++ b/features/basic_layout.feature
@@ -43,6 +43,7 @@ Feature: Setting up basic page layout for site
     And I should see a link "Mentive" to "http://www.mentive.co/"
     And I should see a link "RubyMine" to "https://www.jetbrains.com/ruby/"
     And I should see a link "Blog" to "http://nonprofits.agileventures.org/blog/"
+    And I should see a link "Press Kit" to "http://www.agileventures.org/press-kit"
 
   @javascript @desktop
   Scenario: Show Sponsors on desktop computer

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -144,11 +144,5 @@ describe 'layouts/application.html.erb' do
         expect(footer).to have_link 'Twitter', href: 'https://twitter.com/AgileVentures'
       end
     end
-
-    it 'should render a link to the "Press Kit" page' do
-      rendered.within('#footer') do |footer|
-        expect(footer).to have_link "Press Kit", :href => "http://www.agileventures.org/press-kit"
-      end
-    end
   end
 end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -144,5 +144,11 @@ describe 'layouts/application.html.erb' do
         expect(footer).to have_link 'Twitter', href: 'https://twitter.com/AgileVentures'
       end
     end
+
+    it 'should render a link to the "Press Kit" page' do
+      rendered.within('#footer') do |footer|
+        expect(footer).to have_link "Press Kit", :href => "http://www.agileventures.org/press-kit"
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #1738 

Added a press-kit link to the footer. Also added a rspec test to `application.html.erb_spec.rb` in

```ruby

  context 'within the site footer' do
  ...
  end

```

to test there is a such link called "Press Kit"