### PR TITLE
fix previously turned off js tests

### DIFF
--- a/features/hangouts/edit_youtube_url.feature
+++ b/features/hangouts/edit_youtube_url.feature
@@ -39,7 +39,7 @@ Feature: Manual Edit of Youtube URL
     #
     # see https://github.com/AgileVentures/WebsiteOne/issues/1754
     #
-  @javascript_ignore_js_errors
+  @javascript
   Scenario: Edit Youtube URL and ensure video appears on Project page
     Given the date is "2014 Feb 6th 7:01am"
     And I manually set youtube link with youtube id "cdODZWHUwhc" for event "Repeat Scrum"

--- a/features/users/user_videos.feature
+++ b/features/users/user_videos.feature
@@ -35,7 +35,7 @@ Feature: As a site user
     When I go to my "profile" page
     And I should see video "PP on hello world - feature: 2" in "player"
 
-  @javascript @javascript_ignore_js_errors
+  @javascript
   Scenario: Selecting videos from the list
     Given I have some videos on project "hello world"
     And my YouTube channel is connected


### PR DESCRIPTION
Related to #1754 

I'm trying to turn on js on the tests which had to be turned off to made the develop build pass.