### PR TITLE
[WIP] Add text search form for users on members page

### DIFF
--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -36,6 +36,13 @@ describe 'users/index.html.erb', :type => :view do
       expect(rendered).to have_content('In My Timezone')
       expect(rendered).to have_content('Wider Timezone Area')
     end
+
+    it 'should display a text search form' do
+      render
+
+      expect(rendered).to have_content('User Name')
+      expect(rendered).to have_css('.username-search-form')
+    end
   end
 
   it 'should display a list of users' do


### PR DESCRIPTION
This PR adds a text search form for users on the members page.
fixes #1749 

Note: because of personal matters and work I was not able to commit too much time to this issue, but I'm sure that more will come this week. 