### PR TITLE
support posting links to multiple channels

### DIFF
--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -11,35 +11,37 @@ module SlackService
     return unless Features.slack.notifications.enabled
     return if hangout.hangout_url.blank?
 
-    channel = channel_for_project(hangout.project)
+    channels = channels_for_project(hangout.project)
 
     message = "#{hangout.title}: <#{hangout.hangout_url}|click to join>"
     here_message = "@here #{message}"
     channel_message = "@channel #{message}"
 
     if hangout.category == "Scrum"
-      send_slack_message slack_client, CHANNELS[:general], here_message, hangout.user
-      send_slack_message slack_client, CHANNELS[:standup_notifications], channel_message, hangout.user
+      send_slack_message slack_client, [CHANNELS[:general]], here_message, hangout.user
+      send_slack_message slack_client, [CHANNELS[:standup_notifications]], channel_message, hangout.user
 
     elsif hangout.category == "PairProgramming"
 
-      if channel == CHANNELS[:cs169]
+      if channels.include? CHANNELS[:cs169]
         # puts("sending PP event to gitter: #{channel}")
         send_gitter_message_avoid_repeats gitter_client, "[#{hangout.title} with #{hangout.user.display_name}](#{hangout.hangout_url}) is starting NOW!"
       else
-        send_slack_message slack_client, CHANNELS[:general], here_message, hangout.user
+        send_slack_message slack_client, [CHANNELS[:general]], here_message, hangout.user
         # puts("sending PP event to slack: #{channel}")
       end
-      send_slack_message slack_client, CHANNELS[:pairing_notifications], channel_message, hangout.user
+      send_slack_message slack_client, [CHANNELS[:pairing_notifications]], channel_message, hangout.user
     end
     # send all types of events to associated project "channel" if there is one
-    if channel
-      send_slack_message slack_client, channel, here_message, hangout.user
+    if channels
+      send_slack_message slack_client, channels, here_message, hangout.user
     end
   end
 
-  def send_slack_message(client, channel, text, user)
-    client.chat_postMessage(channel: channel, text: text, username: user.display_name, icon_url: user.gravatar_url, link_names: 1)
+  def send_slack_message(client, channels, text, user)
+    channels.each do |channel|
+      client.chat_postMessage(channel: channel, text: text, username: user.display_name, icon_url: user.gravatar_url, link_names: 1)
+    end
   end
 
   def send_gitter_message_avoid_repeats(gitter_client, text)
@@ -49,37 +51,31 @@ module SlackService
     gitter_client.send_message(text, GITTER_ROOMS[:'saasbook/MOOC'])
   end
 
-  def channel_for_project(project)
-    return nil if project.nil? or project.slug.nil?
-    CHANNELS[project.try(:slug).to_sym]
-  end
-
   def post_yt_link(hangout, client = Slack::Web::Client.new(logger: Rails.logger))
     return unless Features.slack.notifications.enabled
     return if hangout.yt_video_id.blank?
 
-    channel = channel_for_project(hangout.project)
+    channels = channels_for_project(hangout.project)
 
     video = "https://youtu.be/#{hangout.yt_video_id}"
     message = "Video/Livestream: <#{video}|click to play>"
 
     if hangout.category == "Scrum"
-      send_slack_message client, CHANNELS[:general], message, hangout.user
+      send_slack_message client, [CHANNELS[:general]], message, hangout.user
     elsif hangout.category == "PairProgramming"
-      channel = channel_for_project(hangout.project)
-      unless channel == CHANNELS[:cs169]
-        send_slack_message client, CHANNELS[:general], message, hangout.user
+      unless channels.include? CHANNELS[:cs169]
+        send_slack_message client, [CHANNELS[:general]], message, hangout.user
       end
     end
 
-    send_slack_message client, channel, message, hangout.user if channel
+    send_slack_message client, channels, message, hangout.user if channels
 
   end
 
   if ENV['LIVE_ENV'] == 'production'
     CHANNELS = {
         "asyncvoter": "C2HGJF54G",
-        "autograder": "C0UFNHRAB",
+        "autograder": ["C0UFNHRAB","C02AHEA5P"],
         "betasaasers": "C02AHEA5P",
         "binghamton-university-bike-share": "C033Z02P9",
         "codealia": "C0297TUQC",
@@ -89,6 +85,7 @@ module SlackService
         "educhat": "C02AD0LG0",
         "esaas-mooc": "C02A6835V",
         "eventmanager": "C39J4DTP0",
+        "agileventures-community": ["C3Q9A5ZJA", "C02P3CAPA"],
         "metplus": "C09LSBWER",
         "localsupport": "C0KK907B5",
         "osra-support-system": "C02AAM8SY",
@@ -117,8 +114,10 @@ module SlackService
     }
   else
     CHANNELS =    {
+        "multiple-channels": ["C69J9GC1Y", "C29J4QQ9W"],
         "cs169": "C29J4CYA2",
         "websiteone": "C29J4QQ9W",
+        "localsupport": "C69J9GC1Y",
         "general": "C0TLAE1MH",
         "pairing_notifications": "C29J3DPGW",
         "standup_notifications": "C29JE6HGR",
@@ -129,5 +128,15 @@ module SlackService
         "saasbook/AV102": "56b8bdffe610378809c070cc",
         "AgileVentures/agile-bot": "56b8bdffe610378809c070cc"
     }
+  end
+
+
+  private
+
+  def channels_for_project(project)
+    return [] if project.nil? or project.slug.nil?
+    result = CHANNELS[project.try(:slug).to_sym]
+    return [result] unless result.respond_to? :each
+    result
   end
 end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -35,6 +35,12 @@ describe SlackService do
           text: here_message,
       }.merge!(default_post_args)
     end
+    let(:localsupport_project_channel_post_args) do
+      {
+          channel: 'C69J9GC1Y',
+          text: here_message,
+      }.merge!(default_post_args)
+    end
     let(:cs169_project_channel_post_args) do
       {
           channel: 'C29J4CYA2',
@@ -54,10 +60,15 @@ describe SlackService do
       }.merge!(default_post_args)
     end
 
-    context('PairProgramming') do
-      let(:websiteone_project) { mock_model Project, slug: 'websiteone' }
+    let(:cs169_project) { mock_model Project, slug: 'cs169' }
+    let(:websiteone_project) { mock_model Project, slug: 'websiteone' }
 
+    context('PairProgramming') do
+
+      let(:cs169_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: cs169_project }
+      let(:missing_url_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "  ", user: user }
       let(:websiteone_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: websiteone_project }
+      let(:no_project_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: nil }
 
       it 'sends the correct slack message to the correct channels when associated with a project' do
         expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
@@ -67,8 +78,6 @@ describe SlackService do
         slack_service.post_hangout_notification(websiteone_hangout, slack_client, gitter_client)
       end
 
-      let(:no_project_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: nil }
-
       it 'does not fail when event has no associated project' do
         expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
         expect(slack_client).to receive(:chat_postMessage).with(pairing_notifications_channel_post_args)
@@ -76,38 +85,46 @@ describe SlackService do
         slack_service.post_hangout_notification(no_project_hangout, slack_client, gitter_client)
       end
 
-      let(:cs169_project) { mock_model Project, slug: 'cs169' }
-      let(:cs169_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: cs169_project }
-
       it 'should ping gitter and slack (but not general) when the project is cs169' do
         expect(gitter_client).to receive(:messages).with('56b8bdffe610378809c070cc', limit: 50).and_return([])
         expect(gitter_client).to receive(:send_message).with('[MockEvent with random](mock_url) is starting NOW!', "56b8bdffe610378809c070cc")
-        expect(slack_client).to receive(:chat_postMessage).with(cs169_project_channel_post_args)
         expect(slack_client).to receive(:chat_postMessage).with(pairing_notifications_channel_post_args)
+        expect(slack_client).to receive(:chat_postMessage).with(cs169_project_channel_post_args)
 
         slack_service.post_hangout_notification(cs169_hangout, slack_client, gitter_client)
       end
-
-      let(:missing_url_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "  ", user: user }
 
       it 'does not post notification if hangout url is blank' do
         expect(slack_client).not_to receive(:chat_postMessage)
 
         slack_service.post_hangout_notification(missing_url_hangout, slack_client, gitter_client)
       end
+
+      let(:multiple_channel_project) { mock_model Project, slug: 'multiple-channels' }
+      let(:multiple_channel_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: multiple_channel_project }
+
+      it 'can post to multiple channels' do
+        expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
+        expect(slack_client).to receive(:chat_postMessage).with(websiteone_project_channel_post_args)
+        expect(slack_client).to receive(:chat_postMessage).with(localsupport_project_channel_post_args)
+        expect(slack_client).to receive(:chat_postMessage).with(pairing_notifications_channel_post_args)
+
+        slack_service.post_hangout_notification(multiple_channel_hangout, slack_client, gitter_client)
+      end
     end
 
     context('Scrums') do
-      let(:hangout) { EventInstance.create(title: 'MockEvent', category: "Scrum", hangout_url: "mock_url", user: user) }
+      let(:cs169_hangout) { mock_model EventInstance, title: 'MockEvent', category: "Scrum", hangout_url: "mock_url", user: user, project: cs169_project }
+      let(:missing_url_hangout) { mock_model EventInstance, title: 'MockEvent', category: "Scrum", hangout_url: "  ", user: user }
+      let(:websiteone_hangout) { mock_model EventInstance, title: 'MockEvent', category: "Scrum", hangout_url: "mock_url", user: user, project: websiteone_project }
+      let(:no_project_hangout) { mock_model EventInstance, title: 'MockEvent', category: "Scrum", hangout_url: "mock_url", user: user, project: nil }
 
       it 'sends the correct slack message to the correct channels' do
-        hangout.project = Project.create(title: 'websiteone', description: 'hmm', status: 'active')
-
         expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
         expect(slack_client).to receive(:chat_postMessage).with(websiteone_project_channel_post_args)
         expect(slack_client).to receive(:chat_postMessage).with(standup_notifications_channel_post_args)
 
-        slack_service.post_hangout_notification(hangout, slack_client, gitter_client)
+        slack_service.post_hangout_notification(websiteone_hangout, slack_client, gitter_client)
       end
 
       it 'does not fail when event has no associated project' do
@@ -115,25 +132,21 @@ describe SlackService do
         expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
         expect(slack_client).to receive(:chat_postMessage).with(standup_notifications_channel_post_args)
 
-        slack_service.post_hangout_notification(hangout, slack_client, gitter_client)
+        slack_service.post_hangout_notification(no_project_hangout, slack_client, gitter_client)
       end
 
       it 'should ping slack when the project is cs169' do
-        hangout.project = Project.create(title: 'cs169', description: 'hmm', status: 'active')
-
         expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
         expect(slack_client).to receive(:chat_postMessage).with(cs169_project_channel_post_args)
         expect(slack_client).to receive(:chat_postMessage).with(standup_notifications_channel_post_args)
 
-        slack_service.post_hangout_notification(hangout, slack_client, gitter_client)
+        slack_service.post_hangout_notification(cs169_hangout, slack_client, gitter_client)
       end
 
       it 'does not post notification if hangout url is blank for pairing' do
-        hangout.hangout_url = "     "
-
         expect(slack_client).not_to receive(:chat_postMessage)
 
-        slack_service.post_hangout_notification(hangout, slack_client, gitter_client)
+        slack_service.post_hangout_notification(missing_url_hangout, slack_client, gitter_client)
       end
 
     end


### PR DESCRIPTION
fixes #1943

So here I've added the ability to ping multiple slack channels - and added a test to ensure that works for pair programming.

I've updated the channels so that the marketing meeting will ping the marketing channel and av_community channel and that the autograders meeting will also ping the betasaasers channel ...

I've also merged in the minor refactoring of using mock_model, but I'm worried that this is all getting a bit messy, and we need to maybe re-design pushing from TDD.  

I guess the key thing I want to move towards is supporting private events that would ping premium_extra - that's a bigger undertaking ...

also, the specs are rather difficult to follow, and maybe driving from Cucumber would make this all more comprehensible ...