### PR TITLE
fixes #2017 - WebsiteOne appears in the pages title

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -3,7 +3,7 @@
       window._rails_env = "<%= Rails.env %>"
   <% end %>
   <%= render 'layouts/meta_tags' %>
-  <title><%= content_for?(:title) ? [ yield(:title),  ' | AgileVentures - WebsiteOne'].join(' ') : 'AgileVentures - WebsiteOne' %></title>
+  <title><%= content_for?(:title) ? [ yield(:title),  '| AgileVentures'].join(' ') : 'AgileVentures' %></title>
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Lato:400,100,900' %>
   <%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Ubuntu' %>

--- a/features/pages.feature
+++ b/features/pages.feature
@@ -106,3 +106,14 @@ Feature: Static pages
     Given the page "About Us" has a child page with title "SubPage1"
     And I am on the static "SubPage1" page
     Then I should see ancestry "Agile Ventures >> About Us >> SubPage1"
+
+  Scenario: The browser tab text should reflect the page the user is on
+    Given I am on the "Home" page
+    Then the "Home" page title should read "Home | AgileVentures"
+    When I click "About"
+    Then I should be on the static "About Us" page
+    And the "About" page title should read "About Us | AgileVentures"
+
+  Scenario: The browser tab of the registration page should say AgileVentures
+    Given I am on the "registration" page
+    Then the "Sign up" page title should read "AgileVentures"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -8,6 +8,8 @@ def path_to(page_name, id = '')
   case name
     when 'home' then
       root_path
+    when 'about' then
+      '/about-us'
     when 'registration' then
       new_user_registration_path
     when 'edit registration' then

--- a/features/step_definitions/pages_steps.rb
+++ b/features/step_definitions/pages_steps.rb
@@ -59,3 +59,8 @@ Then(/^I should see ancestry "([^"]*)"$/) do |str|
     end
   end
 end
+
+Then(/^the "([^"]*)" page title should read "([^"]*)"$/) do |str, title|
+	visit path_to(str)
+	expect(page.title).to eq "#{title}"
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Two acceptance tests were added to the cucumber features set to ensure that the page title displayed to users when they visit the AgileVentures site reflected the page they were viewing or displayed the default 'AgileVentures'.  The view partial, _head.html.erb, was amended to remove the 'WebsiteOne' text.

#### Motivation and Context
Currently when a user visits the AgileVentures site, the browser tab will display a page title which includes the text 'WebsiteOne'. This is not meant to be seen by users, and refers to the name of the project used by the development team.

#### How Has This Been Tested?
Created two cucumber scenarios, one that checks that the title includes the page that the user is on in the browser tab, e.g. if a user is on the 'Home' page, then the browser tab should display 'Home | AgileVentures". A second scenario checks for pages that simply display 'AgileVentures' in the browser tab, e.g. the 'Log in', and 'Sign up' pages.

Other areas of the code base are unaffected

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [] All new and existing tests passed.

fixes #2017