### PR TITLE
Handle nil on Settings.privileged_users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -155,6 +155,7 @@ class User < ApplicationRecord
   end
 
   def is_privileged?
+    return false if Settings.privileged_users.blank?
     Settings.privileged_users.split(',').include?(email)
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,6 +80,11 @@ describe User, type: :model do
     expect(FactoryBot.build(:user)).to respond_to(:is_privileged?)
   end
 
+  it "should return false if 'Settings.privileged_users' is not setup" do
+    Settings.privileged_users = nil
+    expect(FactoryBot.create(:user).is_privileged?).to be false
+  end
+
   describe 'scopes' do
     context '#mail_receiver' do
       let!(:user1) { FactoryBot.create(:user, receive_mailings: false) }
@@ -414,7 +419,6 @@ describe User, type: :model do
       end
 
     end
-
 
     describe '#hangouts_attended_with_more_than_one_participant' do
       subject(:user) { FactoryBot.create(:user, :with_karma, hangouts_attended_with_more_than_one_participant: 1) }


### PR DESCRIPTION
Handle `nil` when `Settings.privileged_users` doesn't exists.

Fixes https://github.com/AgileVentures/WebsiteOne/issues/2209