### PR TITLE
Upgrade ruby to latest version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+
+ruby '2.5.0'
 
 gem 'rails', '~> 5.1', '>= 5.1.5'
 gem 'acts-as-taggable-on'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -751,7 +751,7 @@ DEPENDENCIES
   zeus
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.5.0p0
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
## Upgrade ruby to latest stable version 2.5.0.

#### Description
Upgrade to ruby version 2.5.0 for having the [performance improvements](https://www.ruby-lang.org/en/downloads/) that come with the upgrade.

