### PR TITLE
Query database once for all users

### DIFF
--- a/app/services/karma_calculator.rb
+++ b/app/services/karma_calculator.rb
@@ -1,9 +1,10 @@
 class KarmaCalculator
 
-  attr_reader :user
+  attr_reader :user, :events
 
-  def initialize(user)
+  def initialize(user, events)
     @user = user
+    @events = events
   end
 
   def perform
@@ -55,7 +56,7 @@ class KarmaCalculator
   end
 
   def calculate_hangouts_attended_with_more_than_one_participant(id)
-    EventInstance.all.select do |i|
+    events.select do |i|
       more_than_one?(i) && i.participants.to_unsafe_h.values.any? do |p|
         p['person']['id'] == id
       end

--- a/app/services/karma_calculator.rb
+++ b/app/services/karma_calculator.rb
@@ -57,14 +57,9 @@ class KarmaCalculator
 
   def calculate_hangouts_attended_with_more_than_one_participant(id)
     events.select do |i|
-      more_than_one?(i) && i.participants.to_unsafe_h.values.any? do |p|
-        p['person']['id'] == id
-      end
+      participant = i.participants.to_unsafe_h.values
+      participant.count > 1 && participant.any? { |p| p['person']['id'] == id }
     end.count
-  end
-
-  def more_than_one?(event_instance)
-    !event_instance.participants.nil? && event_instance.participants.to_unsafe_h.values.count > 1
   end
 
   def activity # 6

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -9,8 +9,9 @@ task :fetch_github_last_updates => :environment do
 end
 
 task :karma_calculator => :environment do
-  User.all.each do |usr|
-    KarmaCalculator.new(usr).perform
-    usr.karma.save!
-  end
+  events = EventInstance.all.where.not(participants: nil)
+    User.all.each do |usr|
+      KarmaCalculator.new(usr, events).perform
+      usr.karma.save!
+    end
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -10,8 +10,14 @@ end
 
 task :karma_calculator => :environment do
   events = EventInstance.all.where.not(participants: nil)
-    User.all.each do |usr|
+  User.all.each do |usr|
+    begin
       KarmaCalculator.new(usr, events).perform
       usr.karma.save!
+    rescue => e
+      Rails.logger.error "Error: Occurred while processing KarmaCalculator for User: #{usr.id}"
+      Rails.logger.error e.message
+      Rails.logger.error e.backtrace.join "\n"
     end
+  end
 end

--- a/spec/services/karma_calculator_spec.rb
+++ b/spec/services/karma_calculator_spec.rb
@@ -23,7 +23,8 @@ describe KarmaCalculator do
   context 'for existing members' do
 
     describe 'for old members' do
-      subject { KarmaCalculator.new(user) }
+      subject { KarmaCalculator.new(user, hangouts) }
+      let(:hangouts) { FactoryBot.create_list(:event_instance, 2) }
       let(:user) { FactoryBot.build(:user, :with_karma, created_at: 31.days.ago) }
       let(:karma_points) { subject.perform; user.karma_total }
 
@@ -33,12 +34,12 @@ describe KarmaCalculator do
     end
 
     describe 'for members attending hangouts' do
-      let(:hangout) { FactoryBot.create(:event_instance) }
+      let(:hangouts) { FactoryBot.create_list(:event_instance, 2) }
       # subject {  }
-      let(:user) { FactoryBot.create(:user, :with_karma, created_at: 31.days.ago, gplus: hangout.participants.to_unsafe_h.first.last['person']['id']) }
+      let(:user) { FactoryBot.create(:user, :with_karma, created_at: 31.days.ago, gplus: hangouts[0].participants.to_unsafe_h.first.last['person']['id']) }
 
       it 'gives points for hangout participation' do
-        subject = KarmaCalculator.new(user)
+        subject = KarmaCalculator.new(user, hangouts)
         subject.perform
         expect(user.hangouts_attended_with_more_than_one_participant).to eq 1
       end


### PR DESCRIPTION
#### Description
The database was being queried to grab all EventInstances for each user. The EventInstance query is the same for each user. So that is about 8000 repetitive queries to the database. Moved this query outside of the loop.

#### Motivation and Context
Reoccurring Airbrake issues related to the KarmaCalculator show that an exception is occurring and the process is killed. Issue #2004 in particular due to a bad PG connection and time out.

According to the Heroku website "Scheduled jobs are meant to execute short running tasks or enqueue longer running tasks into a background job queue. Anything that takes longer than a couple of minutes to complete should use a worker dyno to run.” Confirmed this is not being ran on a worker dyno.

Fixes #2221 

#### How Has This Been Tested?
I tested the speed of this rake task on my system and it revealed that it would take anywhere between 1 and 6 seconds to process each User before the change. After the change it is taking less than a second per User.

Before changes: 
- Time elapsed for 100 users is: 236.5s (4 mins). 
- Estimate to run for 8000 users would be over 5 hours.

After changes:    
- Time elapsed for 100 users is: 49.1s (<1 min).
- Real time run for 8000 users was just over an hour.

This is a 5x increase in speed and reduces the load on the database from O(n) to O(1).

Further improvement can be made to increase the speed of the rake task which will reduce the run time to just a couple minutes.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
