### PR TITLE
Show creator and modifier info on event show page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -78,12 +78,16 @@ class EventsController < ApplicationController
     permitted = [
       :name, :category, :for, :project_id, :description, :duration, :repeats,
       :repeats_every_n_weeks, :repeat_ends_string, :time_zone, :creator_id,
-      :start_datetime, :repeat_ends, :repeat_ends_on
+      :start_datetime, :repeat_ends, :repeat_ends_on, :modifier_id
     ]
 
-    params.merge(event: params[:event].merge(creator_id: current_user.id))
+    params.merge(event: params[:event].merge(action_initiator))
           .require(:event)
           .permit(permitted, repeats_weekly_each_days_of_the_week: [])
+  end
+
+  def action_initiator
+    @event && @event.creator_id ? { modifier_id: current_user.id } : { creator_id: current_user.id }
   end
 
   # next_date and start_date are in the same dst or non-dst

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -43,4 +43,8 @@ module EventHelper
   def google_calendar_link(event)
     "https://calendar.google.com/calendar/render?action=TEMPLATE&dates=#{event.next_event_occurrence_with_time[:time].strftime('%Y%m%dT%H%M%SZ')}%2f#{(event.next_event_occurrence_with_time[:time] + @event.duration*60).strftime('%Y%m%dT%H%M%SZ')}&sprop=website:#{auto_link(event.description)}&text=#{event.name}&location=online&sprop=name:AgileVentures&details=#{event.description}"
   end
+
+  def set_column_width
+    @event.modifier_id ? '<div class="col-xs-12 col-sm-2"></div>'.html_safe : '<div class="col-xs-12 col-sm-4"></div>'.html_safe
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -237,7 +237,7 @@ class Event < ApplicationRecord
   def within_current_event_duration?
     after_current_start_time? and before_current_end_time?
   end
-  
+
   def current_start_time
     schedule.previous_occurrence(Time.now)
   end
@@ -260,6 +260,10 @@ class Event < ApplicationRecord
 
   def jitsi_room_link
     "https://meet.jit.si/AV_#{name.tr(' ', '_').gsub(/[^0-9a-zA-Z_]/i, '')}"
+  end
+
+  def modifier
+    User.find modifier_id
   end
 
   private

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -76,8 +76,7 @@
       </div>
   <% end %>
   <% if @event.creator %>
-      <div class="col-xs-12 col-sm-4">
-      </div>
+      <%= set_column_width %>
       <div class="col-xs-12 col-sm-2">
         <div class="row text-center">
           <%= link_to @event.creator.presenter.gravatar_image(size: 80, id: 'user-gravatar', class: 'img-circle'), user_path(@event.creator) %>
@@ -88,7 +87,27 @@
         <div class="row text-center">
           <%= link_to @event.creator.display_name, user_path(@event.creator) %>
         </div>
+        <div class="row text-center">
+          <%= @event.created_at.strftime "%F" %>
+        </div>
       </div>
+  <% end %>
+
+  <% if @event.modifier_id %>
+    <div class="col-xs-12 col-sm-2">
+      <div class="row text-center">
+        <%= link_to @event.modifier.presenter.gravatar_image(size: 80, id: 'user-gravatar', class: 'img-circle'), user_path(@event.modifier) %>
+      </div>
+      <div class="row text-center">
+        updated by:
+      </div>
+      <div class="row text-center">
+        <%= link_to @event.modifier.display_name, user_path(@event.modifier) %>
+      </div>
+      <div class="row text-center">
+        <%= @event.updated_at.strftime "%F" %>
+      </div>
+    </div>
   <% end %>
 
   <div class="col-xs-12 col-sm-6">
@@ -153,7 +172,7 @@
               <%= hidden_field_tag 'project_id', @event.project.id %>
             <% end %>
             <%= hidden_field_tag 'hangout_url', @recent_hangout.try!(:hangout_url) %>
-    
+
             <div class="form-group">
               <label class="control-label sr-only" for="yt_url">Manually modify Youtube link</label>
             </div>

--- a/db/migrate/20180507045056_add_column_modifier_id_to_events.rb
+++ b/db/migrate/20180507045056_add_column_modifier_id_to_events.rb
@@ -1,0 +1,5 @@
+class AddColumnModifierIdToEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :modifier_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180406015134) do
+ActiveRecord::Schema.define(version: 20180507045056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 20180406015134) do
     t.integer "project_id"
     t.integer "creator_id"
     t.string "for"
+    t.integer "modifier_id"
     t.index ["slug"], name: "index_events_on_slug", unique: true
     t.index ["start_datetime"], name: "index_events_on_start_datetime"
   end

--- a/features/events/show_event.feature
+++ b/features/events/show_event.feature
@@ -9,6 +9,7 @@ Feature: Show Events
     Given the following users exist
       | first_name | last_name | email                      | latitude | longitude | updated_at   |
       | Alice      | Jones     | MyEmailAddress@example.com | 59.33    | 18.06     | 1 minute ago |
+      | Billy      | Bob       | MyFakeNews@example.com     | 59.33    | 18.06     | 1 minute ago |
     Given following events exist:
       | name       | description             | category        | start_datetime          | duration | repeats | time_zone | project | repeats_weekly_each_days_of_the_week_mask | repeats_every_n_weeks |
       | Scrum      | Daily scrum meeting     | Scrum           | 2014/02/03 07:00:00 UTC | 150      | never   | UTC       |         |                                           |                       |
@@ -18,12 +19,24 @@ Feature: Show Events
 
 
   @javascript
-  Scenario: Event show page shows creator's icon and links to creator's profile
-    Given that "Alice" created the "Standup" event
+  Scenario: Event show page shows creator's icon, links to creator's profile, and date created
     Given the date is "2016/05/01 09:15:00 UTC"
-    And they view the event "Standup"
-    Then they should see a link to the creator of the event
-    Then they should see the icon of the creator of the event
+    Given that "Alice" created the "Standup" event
+    Then they view the event "Standup"
+    And they should see a link to the creator of the event
+    And they should see the icon of the creator of the event
+    And they should see the date of when it was created
+
+  @javascript
+  Scenario: Event show page shows modifier's icon, links to modifier's profile, and date modified
+    Given the date is "2018/01/01 09:15:00 UTC"
+    Given that "Alice" created the "Standup" event
+    When the date is "2018/05/04 01:00:00 UTC"
+    And that "Billy" modified the "Standup" event
+    Then they view the event "Standup"
+    And they should see a link to the modifier of the event
+    And they should see the icon of the modifier of the event
+    And they should see the date of when it was modified
 
   @javascript
   Scenario Outline: Do not show hangout button until 10 minutes before scheduled start time, and while event is running
@@ -132,7 +145,7 @@ Feature: Show Events
     And I should see link "Event live! Join now" with "http://hangout.test"
     Then I should see "PP Session"
     And I should see "10:00-10:15 (UTC)"
-    
+
   @javascript
   Scenario: Show events information (unstarted)
     Given the date is "2014/02/03 07:01:00 UTC"

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -348,14 +348,36 @@ Then(/^they should see the icon of the creator of the event$/) do
   expect(page).to have_xpath("//a[@href='#{user_path(@event.creator)}']/img[contains(@src, 'https://www.gravatar.com/avatar/0bc83cb571cd1c50ba6f3e8a78ef1346?s=80&d=retro')]")
 end
 
+Then(/^they should see the icon of the modifier of the event$/) do
+  expect(page).to have_xpath("//a[@href='#{user_path(@event.modifier)}']/img[contains(@src, 'https://www.gravatar.com/avatar/8c5d77ccca5d26e3ae00ddb782876d74?s=80&d=retro')]")
+end
+
 Then(/^they should see a link to the creator of the event$/) do
   expect(page).to have_link(@event.creator.display_name, href: user_path(@event.creator))
+end
+
+Then(/^they should see a link to the modifier of the event$/) do
+  expect(page).to have_link(@event.modifier.display_name, href: user_path(@event.modifier))
+end
+
+Then(/^they should see the date of when it was created$/) do
+  expect(page).to have_content(@event.created_at.strftime "%F")
+end
+
+Then(/^they should see the date of when it was modified$/) do
+  expect(page).to have_content(@event.updated_at.strftime "%F")
 end
 
 Given(/^that "([^"]*)" created the "([^"]*)" event$/) do |first_name, event_name|
   @event = Event.find_by(name: event_name)
   @event.creator = User.find_by(first_name: first_name)
   @event.save
+end
+
+Given(/^that "([^"]*)" modified the "([^"]*)" event$/) do |first_name, event_name|
+  step "I am logged in as \"#{first_name}\""
+  step "I visit the edit page for the event named \"#{event_name}\""
+  step "I click the \"Save\" button"
 end
 
 And(/^The box for "([\w]+)" should be checked$/) do |day|

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -35,4 +35,16 @@ describe EventHelper do
       expect(actual_result).to eql expected_result
     end
   end
+
+  describe 'set_column_width' do
+    it 'should be col-sm-2 when modifier_id exists' do
+      @event = FactoryBot.build(:event, name: 'Spec Scrum', modifier_id: 1)
+      expect(set_column_width).to eq('<div class="col-xs-12 col-sm-2"></div>')
+    end
+
+    it 'should be col-sm-4 when modifier_id does not exist' do
+      @event = FactoryBot.build(:event, name: 'Spec Scrum')
+      expect(set_column_width).to eq('<div class="col-xs-12 col-sm-4"></div>')
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'user'
 
 describe Event, :type => :model do
   before(:each) do
@@ -512,7 +513,17 @@ describe Event, :type => :model do
     end
 
   end
-  
+
+  context 'modifier' do
+    it 'responds to modifier' do
+      @event = FactoryBot.build(:event,
+                                 name: 'Spec Scrum',
+                                 modifier_id: 1)
+      expect(User).to receive(:find).with(1)
+      @event.modifier
+    end
+  end
+
   context '#jitsi_room_link' do
     it 'returns correct link' do
       event = FactoryBot.build(:event, name: 'Repeat Scrum-~!@#$')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Displays details for both the creator and modifier of an event on the show page.

Fixes #2301

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently when someone modifies an event the creator info is destroyed.
This is needed so that we can preserve the creator info and show who
modified the event.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added cucumber tests for the event show page to check that both creator
and modifier info exists on the page after an event is edited. Added unit tests where applicable.

#### Screenshots (if appropriate):
See issue #2301 for screenshots

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
