### PR TITLE
Fix intermittent fail in jasmine tests

### DIFF
--- a/spec/javascripts/flash_spec.js
+++ b/spec/javascripts/flash_spec.js
@@ -29,7 +29,7 @@ describe('WebsiteOne FlashMessages module', function() {
       // it appears jasmine uses window.setTimeout internally, so run this again manually
       $(document).trigger('page:load');
       // checks second argument to window.setTimeout
-      expect(timeoutSpy.calls.mostRecent().args[1]).toEqual(5000);
+      expect(timeoutSpy).toHaveBeenCalledWith(jasmine.anything(), 5000)
     });
 
     it('should cause the flash to fade over 0.5 seconds', function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The fail was caused by this expectation expect(timeoutSpy.calls.mostRecent().args[1]).toEqual(5000) where mostRecent().args will sometimes return only one argument instead of two hence .arg[1] gives undefined.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2340 
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
