### PR TITLE
Set tests to fail on first_try

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -7,5 +7,5 @@ default: <%= std_opts %> features
 ci: --format pretty --strict features
 wip: --tags @wip:3 --wip features
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
-first_try:  NEVER_FAIL=true  <%= std_opts %> --format rerun --out rerun.txt features --strict --tags ~@wip
+first_try:  NEVER_FAIL=false  <%= std_opts %> --format rerun --out rerun.txt features --strict --tags ~@wip
 second_try: NEVER_FAIL=false <%= std_opts %> @rerun.txt  --strict --tags ~@wip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

When tests fail on CI there showing as passing. We used to run a
second_try, but that was removed for some reason. Setting first_try to
fail so that failing tests are shown as failing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Created this change to see if it affects CI reporting of failing tests.