### PR TITLE
add phoenix slack channel id to project lookup and prevent posts to nil channels

### DIFF
--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -91,6 +91,7 @@ module SlackService
         "osra-support-system": "C02AAM8SY",
         "github-api-gem": "C02QZ46S9",
         "oodls": "C03GBBASJ",
+        "phoenixone": "C7JANJXC4",
         "projectscope": "C1NJX7KM1",
         "redeemify": "C1FQZHJJX",
         "refugee_tech": "C0GUTH7RS",

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -40,7 +40,9 @@ module SlackService
 
   def send_slack_message(client, channels, text, user)
     channels.each do |channel|
-      client.chat_postMessage(channel: channel, text: text, username: user.display_name, icon_url: user.gravatar_url, link_names: 1)
+      unless channel.nil?
+        client.chat_postMessage(channel: channel, text: text, username: user.display_name, icon_url: user.gravatar_url, link_names: 1)
+      end
     end
   end
 

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -62,6 +62,7 @@ describe SlackService do
 
     let(:cs169_project) { mock_model Project, slug: 'cs169' }
     let(:websiteone_project) { mock_model Project, slug: 'websiteone' }
+    let(:noslack_project) { mock_model Project, slug: 'noslack' }
 
     context('PairProgramming') do
 
@@ -69,6 +70,7 @@ describe SlackService do
       let(:missing_url_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "  ", user: user }
       let(:websiteone_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: websiteone_project }
       let(:no_project_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: nil }
+      let(:project_with_no_slack_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: noslack_project }
 
       it 'sends the correct slack message to the correct channels when associated with a project' do
         expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
@@ -83,6 +85,13 @@ describe SlackService do
         expect(slack_client).to receive(:chat_postMessage).with(pairing_notifications_channel_post_args)
 
         slack_service.post_hangout_notification(no_project_hangout, slack_client, gitter_client)
+      end      
+      
+      it 'does not try to post to slack channel when project has no associated slack channel in lookup table' do
+        expect(slack_client).to receive(:chat_postMessage).with(general_channel_post_args)
+        expect(slack_client).to receive(:chat_postMessage).with(pairing_notifications_channel_post_args)
+
+        slack_service.post_hangout_notification(project_with_no_slack_hangout, slack_client, gitter_client)
       end
 
       it 'should ping gitter and slack (but not general) when the project is cs169' do


### PR DESCRIPTION
fixes #2015
fixes #2187