### PR TITLE
Remove extra space by using %-d format directive

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -201,7 +201,7 @@
   <ol>
     <% @event_instances.each do |event_instance| %>
       <li>
-        <%= link_to "#{event_instance.created_at.strftime '%A, %B %e, %Y'} - link to video", "https://www.youtube.com/watch?v=#{event_instance.yt_video_id}" %>
+        <%= link_to "#{event_instance.created_at.strftime '%A, %B %-d, %Y'} - link to video", "https://www.youtube.com/watch?v=#{event_instance.yt_video_id}" %>
       </li>
     <% end %>
   </ol>

--- a/features/step_definitions/event_instances_steps.rb
+++ b/features/step_definitions/event_instances_steps.rb
@@ -23,7 +23,7 @@ end
 
 Then /^they should see all information for the instance "([^"]*)"$/ do |event_instance|
   event_instance = EventInstance.find_by title: event_instance
-  expect(page).to have_css('#recent_event_list li', text: "#{event_instance.created_at.strftime '%A, %B %e, %Y'} - ")
+  expect(page).to have_css('#recent_event_list li', text: "#{event_instance.created_at.strftime '%A, %B %-d, %Y'} - ")
   expect(page).to have_link("link to video", href: "https://www.youtube.com/watch?v=#{event_instance.yt_video_id}")
 end
 
@@ -37,7 +37,7 @@ Then /^they should see the most (\d+) recent events first$/ do |num_event_instan
   most_recent_events_first = ''
   num_event_instances.to_i.times.reverse_each do |num|
     next_recent_event = starting_date + num.days
-    next_recent_event = next_recent_event.strftime('%A, %B %e, %Y').to_s
+    next_recent_event = next_recent_event.strftime('%A, %B %-d, %Y').to_s
     most_recent_events_first << next_recent_event + '.*'
   end
   expect(page.text).to match(Regexp.new(most_recent_events_first))


### PR DESCRIPTION
Using %e format directive was adding an extra space in the rspec test
matchers.

Here is more information:
https://stackoverflow.com/questions/20129049/random-space-in-rails-datetime-when-using-rspec

And the link to the format directives:
https://apidock.com/ruby/DateTime/strftime

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This is to fix tests that were passing at the end of last month when there were two digit days and now that we're on single digit days the use of %e is in the rspec matcher is adding an extra space. 

Need to use %-d instead.

Fixes #2415 
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
