### PR TITLE
Decrease running time on Cucumber tests

### DIFF
--- a/features/article_vote.feature
+++ b/features/article_vote.feature
@@ -31,7 +31,7 @@ Feature:
 # Logged in
 
   Scenario: I should see the links to Up/Down Vote an article on the article show page
-    Given I am logged in
+    Given I have logged in
     And I am on the "Show" page for article "Ruby is on Fire"
     Then I should see link "Up Vote"
     And I should see link "Down Vote"
@@ -39,13 +39,13 @@ Feature:
 # voting should change vote value
 
   Scenario: I should be able to vote up an article
-    Given I am logged in
+    Given I have logged in
     And I have voted "up" article "Ruby is on Fire"
     And I am on the "Show" page for article "Ruby is on Fire"
     Then I should see a Vote value of "1"
 
   Scenario: I should be able to vote down an article
-    Given I am logged in
+    Given I have logged in
     And I have voted "down" article "JQuery cannot be queried"
     And I am on the "Show" page for article "JQuery cannot be queried"
     Then I should see a Vote value of "-2"
@@ -53,19 +53,19 @@ Feature:
 # See cancel links after voting
 
   Scenario: I should see the link to Cancel Up Vote after voting up an article
-    Given I am logged in
+    Given I have logged in
     And I have voted "up" article "Ruby is on Fire"
     And I am on the "Show" page for article "Ruby is on Fire"
     Then I should see link "Cancel Up Vote"
 
   Scenario: I should see the link to Cancel Down Vote after voting down an article
-    Given I am logged in
+    Given I have logged in
     And I have voted "down" article "Ruby is on Fire"
     And I am on the "Show" page for article "Ruby is on Fire"
     Then I should see link "Cancel Down Vote"
 
   Scenario: I should be able to cancel an up vote on an article
-    Given I am logged in
+    Given I have logged in
     And I have voted "up" article "Ruby is on Fire"
     And I am on the "Show" page for article "Ruby is on Fire"
     And I click the "Cancel Up Vote" link
@@ -73,7 +73,7 @@ Feature:
     And I should see a Vote value of "0"
 
   Scenario: I should be able to cancel a down vote on an article
-    Given I am logged in
+    Given I have logged in
     And I have voted "down" article "JQuery cannot be queried"
     And I am on the "Show" page for article "JQuery cannot be queried"
     And I click the "Cancel Down Vote" link
@@ -83,7 +83,7 @@ Feature:
 # Down Vote an up voted article
 
   Scenario: I should be able to Down vote an up-voted article
-    Given I am logged in
+    Given I have logged in
     And I have voted "up" article "Ruby is on Fire"
     And I am on the "Show" page for article "Ruby is on Fire"
     And I click the "Down Vote" link
@@ -93,7 +93,7 @@ Feature:
 # Up Vote a down voted article
 
   Scenario: I should be able to Up vote a down-voted article
-    Given I am logged in
+    Given I have logged in
     And I have voted "down" article "JQuery cannot be queried"
     And I am on the "Show" page for article "JQuery cannot be queried"
     And I click the "Up Vote" link
@@ -126,7 +126,7 @@ Feature:
 # Visiting User voting twice
 
   Scenario: I should not be able to vote up twice on same article
-    Given I am logged in
+    Given I have logged in
     And I have voted "up" article "Ruby is on Fire"
     And I am on the "Show" page for article "Ruby is on Fire"
     Then I should see a Vote value of "1"
@@ -141,7 +141,7 @@ Feature:
 
 
   Scenario: I should not be able to vote down twice on same article
-    Given I am logged in
+    Given I have logged in
     And I have voted "down" article "Ruby is on Fire"
     And I am on the "Show" page for article "Ruby is on Fire"
     Then I should see a Vote value of "-1"

--- a/features/articles.feature
+++ b/features/articles.feature
@@ -38,7 +38,7 @@ Feature:
     And I should not see "JQuery cannot be queried"
 
   Scenario: Should be able to create a new article from the article index page
-    Given I am logged in
+    Given I have logged in
     When I am on the "Articles" page
     And I click the very stylish "New Article" button
     Then I should see "Create a New Article"
@@ -49,7 +49,7 @@ Feature:
     And I should see "An example of Markdown"
 
   Scenario: Should be able to edit an article from the article show page
-    Given I am logged in
+    Given I have logged in
     And I am on the "Show" page for article "Ruby is on Fire"
     And I click the very stylish "Edit article" button
     Then I should be on the "Edit" page for article "Ruby is on Fire"

--- a/features/documents.feature
+++ b/features/documents.feature
@@ -29,7 +29,7 @@ Feature: Manage Document
     And I should not see the document "Guides"
 
   Scenario: Create a new document
-    Given I am logged in
+    Given I have logged in
     Given I am on the "Show" page for project "hello world"
     When I click the "Join Project" button
     And I click the "Create new document" button
@@ -38,7 +38,7 @@ Feature: Manage Document
     Then I should see "Document was successfully created."
 
   Scenario: Create a new document page should have a back button
-    Given I am logged in
+    Given I have logged in
     Given I am on the "Show" page for project "hello world"
     When I click the "Join Project" button
     And I click the "Create new document" button
@@ -73,7 +73,7 @@ Feature: Manage Document
 
   Scenario: Has a link to edit a document using the Mercury Editor
     Given the document "Guides" has a child document with title "Howto"
-    Given I am logged in
+    Given I have logged in
     And I am on the "Show" page for document "Howto"
     When I click the very stylish "Edit" button
     Then I should be in the Mercury Editor
@@ -81,7 +81,7 @@ Feature: Manage Document
   @javascript
   Scenario: Mercury editor shows Save and Cancel buttons, hides New Document button, Save button works
     Given the document "Guides" has a child document with title "Howto"
-    And I am logged in
+    And I have logged in
     And I am using the Mercury Editor to edit document "Howto"
     Then I should see button "Save" in Mercury Editor
     And I should see button "Cancel" in Mercury Editor
@@ -96,7 +96,7 @@ Feature: Manage Document
   @javascript
   Scenario: Mercury editor Cancel button works
     Given the document "Guides" has a child document with title "Howto"
-    And I am logged in
+    And I have logged in
     And I am using the Mercury Editor to edit document "Howto"
     When I fill in the editable field "Title" for "document" with "My new title"
     And I click "Cancel" in Mercury Editor
@@ -110,7 +110,7 @@ Feature: Manage Document
     Then I should see "You do not have the right privileges to complete action."
 
   Scenario: The Mercury Editor should only work for the documents
-    Given I am logged in
+    Given I have logged in
     And I visit the site
     When I try to edit the page
     Then I should see "You do not have the right privileges to complete action."
@@ -129,7 +129,7 @@ Feature: Manage Document
   @javascript
   Scenario: A user can insert an image
     Given the document "Guides" has a child document with title "Howto"
-    And I am logged in
+    And I have logged in
     And I am using the Mercury Editor to edit document "Howto"
     And I am focused on the "document body" within the Mercury Editor
     When I click on the "Insert Media" button within the Mercury Toolbar
@@ -142,7 +142,7 @@ Feature: Manage Document
   @javascript
   Scenario: Missing Image gets added when a user can inserts an invalid image
     Given the document "Guides" has a child document with title "Howto"
-    And I am logged in
+    And I have logged in
     And I am using the Mercury Editor to edit document "Howto"
     And I am focused on the "document body" within the Mercury Editor
     When I click on the "Insert Media" button within the Mercury Toolbar
@@ -154,7 +154,7 @@ Feature: Manage Document
 
   @javascript @intermittent-ci-js-fail
   Scenario: Insert media model accepts full url youtube links
-    Given I am logged in
+    Given I have logged in
     And I am using the Mercury Editor to edit document "Guides"
     And I am focused on the "document body" within the Mercury Editor
     And I click on the "Insert Media" button within the Mercury Toolbar
@@ -167,7 +167,7 @@ Feature: Manage Document
 
   @javascript @intermittent-ci-js-fail
   Scenario: Insert media model rejects badly formatted youtube links
-    Given I am logged in
+    Given I have logged in
     And I am using the Mercury Editor to edit document "Guides"
     And I am focused on the "document body" within the Mercury Editor
     And I click on the "Insert Media" button within the Mercury Toolbar
@@ -180,7 +180,7 @@ Feature: Manage Document
 
   @javascript
   Scenario: A logged in user could change a document's parent section
-    Given I am logged in
+    Given I have logged in
     And the following documents exist:
       | title         | body             | project     |
       | Decisions     | Examplehere      | hello mars  |

--- a/features/escalating_call_to_action.feature
+++ b/features/escalating_call_to_action.feature
@@ -20,7 +20,7 @@ Feature: Escalating Call to Action
     Then I should be on the "sign up" page
 
   Scenario: Logged in use sees call to action which links to premium subscription page
-    Given I am logged in
+    Given I have logged in
     And I am on the "home" page
     When I click "Upgrade to Premium for additional support"
     Then I should be on the "premium membership" page

--- a/features/events/client_meetings.feature
+++ b/features/events/client_meetings.feature
@@ -8,7 +8,7 @@ Feature: Provide a ClientMeeting Category
     Given following events exist:
       | name       | description             | category        | start_datetime          | duration | repeats | time_zone | project | repeats_weekly_each_days_of_the_week_mask | repeats_every_n_weeks |
       | ClientMtg  | Daily client meeting    | ClientMeeting   | 2014/02/03 11:00:00 UTC | 150      | never   | UTC       |         |                                           |                       |
-    And I am logged in
+    And I have logged in
     And the following projects exist:
       | title | description          | pitch | status | commit_count |
       | WSO   | greetings earthlings |       | active | 2795         |

--- a/features/events/create_events.feature
+++ b/features/events/create_events.feature
@@ -5,7 +5,7 @@ Feature: Events
   I would like to create events
 
   Background:
-    Given I am logged in
+    Given I have logged in
     And the following projects exist:
       | title | description          | pitch | status | commit_count |
       | WSO   | greetings earthlings |       | active | 2795         |
@@ -142,7 +142,7 @@ Feature: Events
     When I dropdown the "Events" menu
     And I click "Upcoming events"
     Then I should see 3 "Biweekly Meeting" events
-    
+
 
 
 # dimensions

--- a/features/events/edit_future_event.feature
+++ b/features/events/edit_future_event.feature
@@ -6,7 +6,7 @@ Feature: Editing an event with a start date in the future
 
   Background:
     Given the date is "2014/02/01 09:15:00 UTC"
-    And I am logged in
+    And I have logged in
     And I am on Events index page
     When I click "New Event"
     And I select "Repeats" to "weekly"

--- a/features/events/edit_past_event.feature
+++ b/features/events/edit_past_event.feature
@@ -5,23 +5,8 @@ Feature: Editing an event with start date in the past
   I would like to edit event details
 
   Background:
-    Given the date is "2016/02/01 09:15:00 UTC"
-    And I am logged in
-    And I am on Events index page
-    When I click "New Event"
-    And I select "Repeats" to "weekly"
-    And I check "Monday"
-    And I check "Thursday"
-    Given I fill in event field:
-      | name        | value         |
-      | Name        | Daily Standup |
-      | Start Date  | 2014-02-04    |
-      | Start Time  | 09:00         |
-      | Description | we stand up   |
-      | End Date    | 2016-03-04    |
-    Then the event is set to end sometime
-    And I click on the "repeat_ends_on" div
-    And I click the "Save" button
+    Given I have logged in
+    And the "Daily Standup" "weekly" event exists
     And I am on Events index page
 
   Scenario: Check that edit page reflects initial settings

--- a/features/events/event_countdown_widget.feature
+++ b/features/events/event_countdown_widget.feature
@@ -19,7 +19,7 @@ Feature: Events page countdown widget
       | PP Session | Pair programming on WSO | PairProgramming | 2014/02/07 10:00:00 UTC | 15 | never   | Eastern Time (US & Canada) |
       | Scrum 2    | Another scrum           | Scrum           | 2014/02/05 10:00:00 UTC | 15 | never   | Eastern Time (US & Canada) |
 
-    And I am logged in
+    And I have logged in
 
   @time-travel-step
   Scenario: Render live Scrum info on events page

--- a/features/events/next_scrum.feature
+++ b/features/events/next_scrum.feature
@@ -21,7 +21,7 @@ Feature: Visibility to the next scrum
       | title       | description          | status |
       | WebsiteOne  | greetings earthlings | active |
       | Autograders | greetings earthlings | active |
-    And I am logged in
+    And I have logged in
 
   @time-travel-step
   Scenario: Next upcoming scrum on home page

--- a/features/events/show_event.feature
+++ b/features/events/show_event.feature
@@ -41,7 +41,7 @@ Feature: Show Events
   @javascript
   Scenario Outline: Do not show hangout button until 10 minutes before scheduled start time, and while event is running
     Given the date is "<date>"
-    And I am logged in
+    And I have logged in
     And I am on the show page for event "Standup"
     Then I <assertion> see hangout button
     Examples:
@@ -79,7 +79,7 @@ Feature: Show Events
     And I should see "Monday, February 01, 2016"
 
   Scenario: Show index of events with a New Event button for logged in user
-    Given I am logged in
+    Given I have logged in
     Given I am on Events index page
     Then I should see "AgileVentures Events"
     And I should see link "New Event"
@@ -97,7 +97,7 @@ Feature: Show Events
     And I should not see "Event Actions"
 
   Scenario: Show an planned event when a user is logged in
-    Given I am logged in
+    Given I have logged in
     And the date is "2014/02/01 09:15:00 UTC"
     And I am on Events index page
     And I click "Scrum"
@@ -119,7 +119,7 @@ Feature: Show Events
       | 45     | minutes  |
 
   Scenario: Don't save with empty name
-    Given I am logged in
+    Given I have logged in
     And I am on Events index page
     When I click "New Event"
     And I fill in event field:

--- a/features/follow.feature
+++ b/features/follow.feature
@@ -16,7 +16,7 @@ Feature: Join projects
 
 
   Scenario: Join a project
-    Given I am logged in
+    Given I have logged in
     And I am not a member of project "hello mars"
     And I am on the "Show" page for project "hello mars"
     And I click the "Join Project" button
@@ -24,7 +24,7 @@ Feature: Join projects
     And I should see "You just joined hello mars"
 
   Scenario: Leave a project
-    Given I am logged in
+    Given I have logged in
     And I am a member of project "hello mars"
     And I am on the "Show" page for project "hello mars"
     And I click "Leave Project"

--- a/features/hangouts/edit_hangout_url.feature
+++ b/features/hangouts/edit_hangout_url.feature
@@ -16,7 +16,7 @@ Feature: Manual Edit of Hangout URL
       | title        | hangout_url         | created_at       | updated_at          | uid | category | project    | user_id | yt_video_id | hoa_status | url_set_directly | event        |
       | HangoutsFlow | http://hangout.test | 2012 Feb 4th 7am | 2012 Feb 4th 7:04am | 100 | Scrum    | Websiteone | 1       | QWERT55     | started    | true             | Repeat Scrum |
       | HangoutsFlow | http://hangout.test | 2014 Feb 4th 7am | 2014 Feb 4th 7:03am | 100 | Scrum    | Websiteone | 1       | QWERT55     | started    | true             | Repeat Scrum |
-    And I am logged in
+    And I have logged in
 
   Scenario: Edit Hangout URL and ensure event stays live
     Given the date is "2014 Feb 4th 6:59am"

--- a/features/hangouts/edit_youtube_url.feature
+++ b/features/hangouts/edit_youtube_url.feature
@@ -17,14 +17,14 @@ Feature: Manual Edit of Youtube URL
       | HangoutsFlow | http://hangout.test | 2012 Feb 4th 7am | 2012 Feb 4th 7:04am | 100 | Scrum    | Websiteone | 1       | QWERT55     | started    | true             | Repeat Scrum |
       | HangoutsFlow | http://hangout.test | 2014 Feb 4th 7am | 2014 Feb 4th 7:03am | 100 | Scrum    | Websiteone | 1       | QWERT55     | started    | true             | Repeat Scrum |
       | Old          | http://hangout.test | 2014 Jan 4th 7am | 2014 Jan 4th 7:03am | 100 | Scrum    | Websiteone | 1       | QWERT55     | started    | true             | Repeat Scrum |
-    And I am logged in
+    And I have logged in
 
   Scenario: Editing Youtube URL has no effect on Hangout URL
     Given the date is "2014 Feb 4th 7:01am"
     And I manually set a hangout link for event "Scrum"
     And I manually set youtube link with youtube id "12341234111" for event "Scrum"
     Then Hangout link does not change for "Scrum"
-        
+
   Scenario: Editing Hangout URL has no effect on Youtube URL
     Given the date is "2014 Feb 4th 7:01am"
     And I manually set youtube link with youtube id "12341234111" for event "Scrum"
@@ -52,15 +52,15 @@ Feature: Manual Edit of Youtube URL
     Given the date is "2014 Feb 7th 7:01am"
     And I manually set a hangout link for event "Scrum"
     When I manually set youtube link with youtube id "12341234111" for event "Scrum"
-    Then a separate event instance is not created  
-    
+    Then a separate event instance is not created
+
   Scenario: Edit past youtube URL
     Given the date is "2014 Feb 10th 7:01am"
     And I visit the "Edit" page for "Old" "event_instance"
     When I fill in "event_instance_yt_video_id" with "http://youtube.com/watch?v=cdODZWHUwhc"
     And I click "Update Event instance"
     Then I should see "Hangout Updated"
-  
+
   Scenario: Edit past youtube URL does not cause an event instance to show as Live
     Given the date is "2014 Feb 10th 7:01am"
     And I visit the "Edit" page for "Old" "event_instance"

--- a/features/hangouts/hangout.feature
+++ b/features/hangouts/hangout.feature
@@ -24,7 +24,7 @@ Feature: Managing hangouts of scrums and PairProgramming sessions
       | Bob        | Anchous   | bob@btinternet.co.uk   | 12345678 | yt_id_2 |
       | Jane       | Anchous   | jan@btinternet.co.uk   | 12345678 | yt_id_3 |
     And there are no videos
-    And I am logged in
+    And I have logged in
     And I have Slack notifications enabled
 
   @javascript

--- a/features/hookups/hookups_active.feature
+++ b/features/hookups/hookups_active.feature
@@ -5,7 +5,7 @@ Feature: Show Active Hookups
   I would like to view and manage active events
 
   Background:
-    Given I am logged in
+    Given I have logged in
     Given the time now is "2014-02-03 09:15:00 UTC"
     Given the following projects exist:
       | title         | description             | pitch       | status   | github_url                                  | pivotaltracker_url                               |

--- a/features/hookups/hookups_pending.feature
+++ b/features/hookups/hookups_pending.feature
@@ -5,7 +5,7 @@ Feature: Show Pending Hookups
   I would like to be able to create pending events
 
   Background:
-    Given I am logged in
+    Given I have logged in
     And the date is "2014-07-15 12:00:00 UTC"
     And following events exist:
       | name     | description    | category        | start_datetime          | duration | repeats | time_zone |

--- a/features/jitsi_meet/start_jitsi_button.feature
+++ b/features/jitsi_meet/start_jitsi_button.feature
@@ -2,7 +2,7 @@ Feature: Start jitsi meet
   As a person involved in an project
   So that I can join a scrum of Pair Programming session
   I would like to be able to start jitsi meet from event page and project page
-  
+
   Background:
     Given the following projects exist:
       |title | description | status |
@@ -10,13 +10,13 @@ Feature: Start jitsi meet
     Given following events exist:
       | name         | description         | category | start_datetime   | duration | repeats | time_zone | repeats_every_n_weeks | repeats_weekly_each_days_of_the_week_mask | project |
       | Repeat Scrum | Daily scrum meeting | Scrum    | 2014 Feb 3rd 7am | 15       | weekly  | UTC       | 1                     | 31                                        |         |
-    And I am logged in
+    And I have logged in
 
   Scenario: Start jitsi meet from event page
     Given the date is "2014 Feb 5th 6:55am"
     And I navigate to the show page for event "Repeat Scrum"
     Then I should see a start jitsi meet button with link "https://meet.jit.si/AV_Repeat_Scrum"
-    
+
   Scenario: Start jitsi meet from project page
     Given the date is "2014 Feb 5th 6:55am"
     And I am on the "Show" page for project "LS"

--- a/features/premium/charge_activity.feature
+++ b/features/premium/charge_activity.feature
@@ -35,7 +35,7 @@ Feature: Charge Users Money
     And I should see "7 day free trial! No charge for 7 days"
 
   Scenario: Sign up for premium f2f membership
-    Given I am logged in
+    Given I have logged in
     And I visit "/subscriptions/new?plan=premiumf2f"
     And I should not see "Sign Me Up For Premium!"
     And I click "Subscribe" within the card_section
@@ -44,7 +44,7 @@ Feature: Charge Users Money
     And the user should receive a "Welcome to AgileVentures Premium F2F" email
 
   Scenario: Sign up for premium plus membership
-    Given I am logged in
+    Given I have logged in
     And  I visit "/subscriptions/new?plan=premiumplus"
     And I should not see "Sign Me Up For Premium!"
     And I click "Subscribe" within the card_section

--- a/features/premium/sponsor_other_member.feature
+++ b/features/premium/sponsor_other_member.feature
@@ -17,7 +17,7 @@ Feature: Allow Users to Sponsor other members
     And the email queue is clear
 
   Scenario: User upgrades another user from free tier to premium via card
-    Given I am logged in
+    Given I have logged in
     And I visit Alice's profile page
     And I click "Sponsor for Premium"
     And I click "Subscribe" within the card_section
@@ -31,7 +31,7 @@ Feature: Allow Users to Sponsor other members
     And I should not see "Upgrade to Premium"
 
   Scenario: User upgrades another user from free tier to premium via PayPal
-    Given I am logged in
+    Given I have logged in
     And I visit Alice's profile page
     And I click "Sponsor for Premium"
     Then I should see a paypal form within the paypal_section
@@ -78,7 +78,7 @@ Feature: Allow Users to Sponsor other members
     And I should not see "Upgrade to Premium"
 
   Scenario: Different User attempts to update an existing Premium user (and won't see button)
-    Given I am logged in
+    Given I have logged in
     When I visit Billy's profile page
     Then I should not see button "Sponsor for Premium Mob"
     And I should not see button "Upgrade to Premium Mob"

--- a/features/premium/subscribe_self_to_premium.feature
+++ b/features/premium/subscribe_self_to_premium.feature
@@ -12,7 +12,7 @@ Feature: Subscribe Self to Premium
     And the email queue is clear
 
   Scenario: Pay by card
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new"
     And I click "Subscribe" within the card_section
     When I fill in appropriate card details for premium
@@ -21,7 +21,7 @@ Feature: Subscribe Self to Premium
     And "random@morerandom.com" should receive a "Welcome to AgileVentures Premium" email
 
   Scenario: Logged in user has sponsor set to self
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new"
     And I click "Subscribe" within the card_section
     When I fill in appropriate card details for premium
@@ -31,7 +31,7 @@ Feature: Subscribe Self to Premium
     And I should be my own sponsor
 
   Scenario: Pay by card (with free trial month)
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new?plan=av_premium_first_month_free"
     And I click "Subscribe" within the card_section
     When I fill in appropriate card details for premium
@@ -42,7 +42,7 @@ Feature: Subscribe Self to Premium
     # And my member page should show premium details # TODO IMPORTANT - require login?
 
   Scenario: Pay by PayPal
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new"
     Then I should see a paypal form within the paypal_section
     When Paypal updates our endpoint
@@ -53,7 +53,7 @@ Feature: Subscribe Self to Premium
 
   Scenario: Pay by card, but encounter error
     Given my card will be rejected
-    And I am logged in
+    And I have logged in
     And I visit "/subscriptions/new"
     And I click "Subscribe" within the card_section
     When I fill in appropriate card details for premium
@@ -62,7 +62,7 @@ Feature: Subscribe Self to Premium
     And "random@morerandom.com" should not receive a "Welcome to AgileVentures Premium" email
 
   Scenario: Pay by PayPal, but encounter error
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new"
     Then I should see a paypal form within the paypal_section
     When Paypal updates our endpoint incorrectly
@@ -70,7 +70,7 @@ Feature: Subscribe Self to Premium
     And I should see "redirected" in last_response
 
   Scenario: Pay by card, and default to Premium
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new?plan=76a5uydstjg"
     And I click "Subscribe" within the card_section
     When I fill in appropriate card details for premium

--- a/features/premium/subscribe_self_to_premium_mob.feature
+++ b/features/premium/subscribe_self_to_premium_mob.feature
@@ -11,7 +11,7 @@ Feature: Subscribe Self to Premium
     And the email queue is clear
 
   Scenario: Pay by card
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new?plan=premiummob"
     And I click "Subscribe" within the card_section
     When I fill in appropriate card details for premium mob
@@ -21,7 +21,7 @@ Feature: Subscribe Self to Premium
     # And my member page should show premium details # TODO IMPORTANT - require login?
 
   Scenario: Pay by PayPal
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new?plan=premiummob"
     Then I should see a paypal form within the paypal_section
     When Paypal updates our endpoint for premium mob
@@ -31,7 +31,7 @@ Feature: Subscribe Self to Premium
     # And my member page should show premium details # TODO IMPORTANT - will need hookup
 
   Scenario: Pay by card, but encounter error
-    Given I am logged in
+    Given I have logged in
     And my card will be rejected
     And I visit "/subscriptions/new?plan=premiummob"
     And I click "Subscribe" within the card_section
@@ -41,7 +41,7 @@ Feature: Subscribe Self to Premium
     And "random@morerandom.com" should not receive a "Welcome to AgileVentures Premium Mob" email
 
   Scenario: Pay by PayPal, but encounter error
-    Given I am logged in
+    Given I have logged in
     And I visit "subscriptions/new?plan=premiummob"
     Then I should see a paypal form within the paypal_section
     When Paypal updates our endpoint incorrectly

--- a/features/premium/upgrade_membership.feature
+++ b/features/premium/upgrade_membership.feature
@@ -18,14 +18,14 @@ Feature: Allow Users to Upgrade Membership
       | Alice      | Jones     | alice@btinternet.co.uk | http://github.com/AliceSky | 127.0.0.1       |
 
   Scenario: User is on free tier and looking at own page
-    Given I am logged in
+    Given I have logged in
     And I am on my profile page
     Then I should see "Basic Member"
     And I should not see "Premium Member"
     And I should not see "Premium Mob Member"
 
   Scenario: User is on free tier and looking at other persons profile page
-    Given I am logged in
+    Given I have logged in
     And I visit Alice's profile page
     Then I should see "Basic Member"
     And I should not see "Premium Member"
@@ -34,7 +34,7 @@ Feature: Allow Users to Upgrade Membership
     And I should not see button "Upgrade to Premium Mob"
 
   Scenario: User upgrades to premium from free tier
-    Given I am logged in
+    Given I have logged in
     When I am on my profile page
     Then I should see a tooltip explanation of Premium
     And I click "Upgrade to Premium"
@@ -74,7 +74,7 @@ Feature: Allow Users to Upgrade Membership
     When I click "Upgrade to Premium Mob"
     Then I should see "Please email info@agileventures.org to receive an upgrade"
     And I should not see "Premium Mob Member"
-  
+
   Scenario: CraftAcademy student upgrades premium plan to premium mob via Stripe but fails
     Given I am logged in as a CraftAcademy premium user
     And I am on my profile page
@@ -82,4 +82,4 @@ Feature: Allow Users to Upgrade Membership
     When I click "Upgrade to Premium Mob"
     Then I should see "Please email info@agileventures.org to receive an upgrade"
     And I should not see "Premium Mob Member"
-    
+

--- a/features/projects/create_projects.feature
+++ b/features/projects/create_projects.feature
@@ -5,7 +5,7 @@ Feature: Create projects
   I would like to create a new project profile
 
   Scenario: Show New Project button if user is logged in
-    When I am logged in
+    When I have logged in
     And I am on the "projects" page
     Then I should see the very stylish "New Project" button
 
@@ -15,7 +15,7 @@ Feature: Create projects
     Then I should not see the very stylish "New Project" button
 
   Scenario: Creating a new project
-    Given I am logged in
+    Given I have logged in
     And I am on the "projects" page
     When I click the very stylish "New Project" button
     Then I should see "Creating a new Project"
@@ -28,7 +28,7 @@ Feature: Create projects
       | Issue Tracker link   |
 
   Scenario Outline: Saving a new project: success
-    Given I am logged in
+    Given I have logged in
     And I am on the "Projects" page
     When I click the very stylish "New Project" button
     When I fill in "Title" with "<title>"
@@ -53,7 +53,7 @@ Feature: Create projects
       | Title New | Description New | http://www.github.com/new | http://www.pivotaltracker.com/n/projects/982890 |
 
   Scenario: Saving a new project: failure
-    Given I am logged in
+    Given I have logged in
     And I am on the "projects" page
     And I click the very stylish "New Project" button
     When I fill in "Title" with ""
@@ -62,7 +62,7 @@ Feature: Create projects
 
   @javascript
   Scenario: Saving a new project with multiple repositories: success
-    Given I am logged in
+    Given I have logged in
     And I am on the "Projects" page
     When I click the very stylish "New Project" button
     When I fill in "Title" with "multiple repo project"

--- a/features/projects/edit_project.feature
+++ b/features/projects/edit_project.feature
@@ -21,20 +21,20 @@ Feature: Edit Project
 
   @javascript
   Scenario: Existing project with multiple repos shows them correctly in edit form
-    Given I am logged in
+    Given I have logged in
     And that project "hello world" has an extra repository "https://github.com/AgileVentures/WebsiteOne"
     When I am on the "Edit" page for projects "hello world"
     Then I should see "GitHub url (primary)"
     And I should see "GitHub url (2)"
 
   Scenario: Edit page has a return link
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for projects "hello mars"
     When I click "Back"
     Then I should be on the "Show" page for project "hello mars"
 
   Scenario: Updating a project: success
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for project "hello mars"
     And I fill in "Description" with "Hello, Uranus!"
     And I fill in "GitHub url (primary)" with "https://github.com/google/instant-hangouts"
@@ -47,14 +47,14 @@ Feature: Edit Project
     And I should see a link to "hello mars" on Pivotal Tracker
 
   Scenario: Saving a project: failure
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for project "hello mars"
     When I fill in "Title" with ""
     And I click the "Submit" button
     Then I should see "Project was not updated."
 
   Scenario: Update GitHub url if valid
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for project "hello mars"
     And I fill in "GitHub url (primary)" with "https://github.com/google/instant-hangouts"
     And I click the "Submit" button
@@ -62,7 +62,7 @@ Feature: Edit Project
     And I should see a link to "hello mars" on github
 
   Scenario: Update Issue Tracker url if valid pivotal tracker link
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for project "hello mars"
     And I fill in "Issue Tracker link" with "https://www.pivotaltracker.com/s/projects/853345"
     And I click the "Submit" button
@@ -70,7 +70,7 @@ Feature: Edit Project
     And I should see a link to "hello mars" on Pivotal Tracker
 
   Scenario: Reject GitHub url update if invalid
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for project "hello mars"
     And I fill in "GitHub url (primary)" with "https:/github.com/google/instant-hangouts"
     And I click the "Submit" button

--- a/features/projects/project_videos.feature
+++ b/features/projects/project_videos.feature
@@ -5,7 +5,7 @@ Feature: See project related videos
   I would like to see a list of videos on a project page
 
   Background:
-    Given I am logged in
+    Given I have logged in
     And the following projects exist:
       | title       | description          | status   | tags            |
       | hello world | greetings earthlings | active   | WSO, WebsiteOne |

--- a/features/projects/show_project.feature
+++ b/features/projects/show_project.feature
@@ -41,7 +41,7 @@ Feature: Display Projects
     And I should see links to "HelloSunExtras" on github
 
   Scenario: Project show page has hangout button for users that not follow the project
-    Given I am logged in
+    Given I have logged in
     And I am on the "Show" page for project "hello world"
     When I click "Start Live Hangout" button
     Then I should see "You should join this project before you can start the hangouts"

--- a/features/public_activity.feature
+++ b/features/public_activity.feature
@@ -18,7 +18,7 @@ Feature: Display Public Activity
       | Title           | Content                | Tag List    |
       | Ruby is on Fire | Fire is fire and sunny | Ruby, Rails |
 
-    Given I am logged in
+    Given I have logged in
     And I edit article "Ruby is on Fire"
     And I create a document named "A New Guide to the Galaxy"
     And I create a project named "Build NCC-1701 Enterprise"

--- a/features/sidebar.feature
+++ b/features/sidebar.feature
@@ -22,7 +22,7 @@ Feature: Sidebar navigation
 
 
   Scenario: Sidebar is always visible
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for project "hello mars"
     Then I should see the sidebar
     Given I am on the "Show" page for project "hello mars"
@@ -33,7 +33,7 @@ Feature: Sidebar navigation
     Then I should see the sidebar
 
   Scenario: Sidebar always shows the relevant information
-    Given I am logged in
+    Given I have logged in
     And I am on the "Show" page for document "Howto 2"
     Then I should see a link to "Show" page for project "hello world" within the sidebar
     And I should see a link to "Show" page for document "Howto" within the sidebar
@@ -46,7 +46,7 @@ Feature: Sidebar navigation
     Given I am on the "projects" page
     Then I should see "hello moon" before "hello pluto"
     And I should see "hello pluto" before "hello world"
-    Given I am logged in
+    Given I have logged in
     And I am on the "Edit" page for project "hello mars"
     Then I should see "hello moon" before "hello pluto"
     And I should see "hello pluto" before "hello world"

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -2,6 +2,20 @@ Given(/^I visit the edit page for the event named "(.*?)"$/) do |event_name|
   visit edit_event_path(Event.find_by(name: event_name))
 end
 
+Given /^the "([^"]*)" "([^"]*)" event exists$/ do |event_name, repeat|
+  Event.create name: event_name,
+               category: "Scrum",
+               description: "we stand up",
+               repeats: repeat,
+               repeats_every_n_weeks: 1,
+               repeats_weekly_each_days_of_the_week_mask: 9,
+               repeat_ends: true,
+               repeat_ends_on: "Fri, 04 Mar 2016",
+               time_zone: "UTC",
+               start_datetime: "Tue, 04 Feb 2014 09:00:00 UTC +00:00",
+               duration: 30
+end
+
 Then(/^the "(.*?)" selector should be set to "(.*?)"$/) do |selector, value|
   #note: expect(page).to have_select(selector, selected: "on") passes right now which encodes the error
   #delete this after finishing this feature

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -65,6 +65,11 @@ Given /^I am logged in$/ do
   sign_in
 end
 
+Given /^I have logged in$/ do
+  create_user
+  login_as @user, :scope => :user
+end
+
 Given /^I exist as a user$/ do
   create_user
 end

--- a/features/users/profile_privacy.feature
+++ b/features/users/profile_privacy.feature
@@ -40,7 +40,7 @@ Feature: As a site user
     Then I should see "Bob Butcher"
 
   Scenario: Email should be private by default
-    Given I am logged in
+    Given I have logged in
     And I am on my "Profile" page
     Then I should not see my email
 
@@ -54,7 +54,7 @@ Feature: As a site user
 
   @javascript
   Scenario: Should be able to make my email public
-    Given I am logged in
+    Given I have logged in
     And I am on my "Edit Profile" page
     And "Display email" should not be checked
     When I set my email to be public
@@ -64,7 +64,7 @@ Feature: As a site user
 
   @javascript
   Scenario: Should be able to make my email private again
-    Given I am logged in
+    Given I have logged in
     And My email was set to public
     And I am on my "Edit Profile" page
     Then "Display email" should be checked
@@ -74,13 +74,13 @@ Feature: As a site user
     Then I should not see my email
 
   Scenario: Hire Me button should be private by default
-    Given I am logged in
+    Given I have logged in
     And I sign out
     And I am on my "Profile" page
     Then I should not see button "Hire me"
 
   Scenario: Should be able to make my Hire Me button public
-    Given I am logged in
+    Given I have logged in
     And I am on my "Edit Profile" page
     And "Display Hire Me" should not be checked
     When I set my Hire Me to be public
@@ -90,7 +90,7 @@ Feature: As a site user
     Then I should see button "Hire me"
 
   Scenario: Should be able to make my Hire Me button private again
-    Given I am logged in
+    Given I have logged in
     And My hire me was set to public
     And I am on my "Edit Profile" page
     Then "Display Hire Me" should be checked
@@ -101,7 +101,7 @@ Feature: As a site user
     Then I should not see button "Hire me"
 
   Scenario: Should not be able to see Hire Me button when logged in
-    Given I am logged in
+    Given I have logged in
     And I am on my "Edit Profile" page
     And "Display Hire Me" should not be checked
     When I set my Hire Me to be public

--- a/features/users/sign_out.feature
+++ b/features/users/sign_out.feature
@@ -5,7 +5,7 @@ Feature: Sign out
   Should be able to sign out
 
   Scenario: User signs out
-    Given I am logged in
+    Given I have logged in
     When I sign out
     Then I should see a signed out message
     When I return to the site

--- a/features/users/user_bio.feature
+++ b/features/users/user_bio.feature
@@ -16,7 +16,7 @@ Feature: User bio
 
   @javascript
   Scenario: Add bio content to profile
-    Given I am logged in
+    Given I have logged in
     And I am on "profile" page for user "me"
     And I click the "Edit" button
     And I fill in "Bio" with "Lives on a farm with many sheep and goats"

--- a/features/users/user_videos.feature
+++ b/features/users/user_videos.feature
@@ -4,7 +4,7 @@ Feature: As a site user
   I would like to see these videos at the member profile
 
   Background:
-    Given I am logged in
+    Given I have logged in
     And the following projects exist:
       | title       | description          | status   | tags            |
       | hello world | greetings earthlings | active   | WSO, WebsiteOne |

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,5 @@
+include Warden::Test::Helpers
+Warden.test_mode!
 FactoryBot.define do
   factory :user, aliases: [:whodunnit] do
     trait(:with_karma) {  karma { Karma.new } }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,6 +81,12 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 end
 
+RSpec.configure do |config|
+  config.after :each do
+    Warden.test_reset!
+  end
+end
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec


### PR DESCRIPTION
Multiple tests rely on a user being signed in. When a user needs to be signed in for a test then prior to that test run capybara is driving to the webpage, filling out the form, submitting, and waits for a reply.

Having a method that stubs the sign in process will not only improve the tests listed below, but all tests that can run with a stubbed sign in.

Fortunately Devise has a Module called Warden that does this. Configured Warden and set most tests to sign in via Warden.

Also removed all capybara methods and assertions in the Cucumber background job since it is a setup job that doesn't/shouldn't test functionality as it should be used to setup a state for the tests to run in. Since the background job is ran before each test in the feature than improving this one job has improved overall test speed.

Fixes #1496 
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Semaphore has listed the following tests as taking a long time to run.

- [x] 1 features/events/edit_past_event.feature
- [x] 2 features/events/list_repeating_events.feature
- [x] 3 features/hookups/hookups_pending.feature
- [x] 4 features/hangouts/edit_hangout_url.feature

Will also update other tests where possible to use Warden's login_as method
- [x] Update tests across site to use Warden's stubbed login method


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To decrease overall test run time

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Overall the whole test suites runs about a minute faster than before. 
The edit_past_event.feature runs about 2x faster now
And not much improvement on the other tests as there is only 1 or two scenario's there and they already run in about 1 - 2 seconds.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
