### PR TITLE
Use AgileVentures forked Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.5.1'
 
 gem 'rails', '~> 5.1'
 gem 'acts-as-taggable-on'
-gem 'acts_as_follower', git: 'https://github.com/tcocca/acts_as_follower.git'
+gem 'acts_as_follower', git: 'https://github.com/AgileVentures/acts_as_follower.git'
 gem 'acts_as_tree'
 gem 'acts_as_votable', '~> 0.11.1'
 gem 'airbrake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/AgileVentures/acts_as_follower.git
+  revision: 894b44451c609a9facfdb8a15bca4fc17ea1eb76
+  specs:
+    acts_as_follower (0.2.1)
+      activerecord (>= 4.0)
+
+GIT
   remote: https://github.com/AgileVentures/codeclimate_badges
   revision: 88f15dfae8679a7895e8fa3cf6a9cb39f665745e
   specs:
@@ -12,13 +19,6 @@ GIT
     mercury-rails (0.9.0)
       coffee-rails (>= 3.2.2)
       railties (>= 3.0)
-
-GIT
-  remote: https://github.com/tcocca/acts_as_follower.git
-  revision: c5ac7b9601c4af01eb4d9112330b27be4d694ecc
-  specs:
-    acts_as_follower (0.2.1)
-      activerecord (>= 4.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
#### Description
`acts_as_follower` gem is no longer maintained. Forked Gem to fix deprecation
warning spamming the output of our tests.
Deprecation warning for use of custom classes is spamming the output of tests. Applied patch. See https://github.com/AgileVentures/acts_as_follower/pull/1 for more info.

Tests passing with zero instances of a deprecation warning printing, it will still print to the output if a custom class is actually used.

Fixes #2499 

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
