### PR TITLE
Remove db host from database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,6 @@ development: &dev
   encoding: unicode
   database: websiteone_development
   pool: 20
-  host: db
   username: postgres
   password:
 test: &test


### PR DESCRIPTION
Pointing to host db prevents local developers from running server and visiting site