### PR TITLE
Add error handling to Slack/Gitter API calls

### DIFF
--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -43,7 +43,7 @@ class EventInstancesController < ApplicationController
 
   def send_messages_to_social_media event, event_params, hangout_url_changed
     begin
-      SlackService.post_hangout_notification(event) if updating_hangout_url?(event, event_params, hangout_url_changed)
+      SlackService.post_hangout_notification(event) if updating_hangout_url?(event, hangout_url_changed)
       SlackService.post_yt_link(event) if updating_valid_yt_url?(event, event_params)
       TwitterService.tweet_hangout_notification(event) if (hangout_started?(event) && hangout_url_changed)
       TwitterService.tweet_yt_link(event)
@@ -56,7 +56,7 @@ class EventInstancesController < ApplicationController
     flash[:notice] = "Hangout successfully posted"
   end
 
-  def updating_hangout_url? event, event_params, hangout_url_changed
+  def updating_hangout_url? event, hangout_url_changed
     (slack_notify_hangout? && event.hangout_url?) || (hangout_started?(event) && hangout_url_changed)
   end
 

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -15,7 +15,7 @@ module SlackService
     @here_message = "@here #{@message}"
     @channel_message = "@channel #{@message}"
 
-    send_notifications hangout.category, slack_client, gitter_client, hangout, channels
+    send_notifications slack_client, gitter_client, hangout, channels
   end
 
   def send_slack_message(client, channels, text, user)
@@ -144,8 +144,8 @@ module SlackService
                        @channel_message, hangout.user
   end
 
-  def send_notifications event_type, slack_client, gitter_client, hangout, channels
-    case event_type
+  def send_notifications slack_client, gitter_client, hangout, channels
+    case hangout.category
     when "Scrum"
       post_scrum_notification slack_client, gitter_client, hangout
     when "PairProgramming"


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Refactored Event Instance update method and the Slack Services post method, and added error handling for any events that may occur when communicating with external services.

Fixes #2452 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is mainly in response to recent issues that caused end users to see a 500 error message without any explanation of what happened. The main culprit was an invalid API token, which has now been updated. 

#### Screenshots (if appropriate):
Screen shot for when an error occurs.

<img width="752" alt="screenshot 2018-08-08 16 01 59" src="https://user-images.githubusercontent.com/19519317/43872952-45bf1266-9b39-11e8-99de-e814a0546965.png">

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
