### PR TITLE
Update null user to have an id

### DIFF
--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -5,7 +5,7 @@ class NullUser < User
   end
 
   def initialize(name)
-    super({ first_name: name, created_at: Time.now })
+    super({ id: -1, first_name: name, created_at: Time.now })
   end
 
   def presenter

--- a/app/views/projects/_listing.html.erb
+++ b/app/views/projects/_listing.html.erb
@@ -35,19 +35,15 @@
               <li data-toggle="tooltip" data-placement="top" title="<%= commit_count %> <%= 'commit'.pluralize(commit_count) %>">
                 <i class="fa fa-github-alt"></i> <%= commit_count %>
               </li>
+              <% end %>
             </ul>
-            <% end %>
           </div>
           <div style="display: inline-block; font-size: 1.0em; font-style: italic;">
             <div>Status: <strong style="font-style: normal;"><%= project.status.upcase %></strong></div>
             <div>Last update in Github: <%= project.last_github_update %></div>
             <div>
             <%= "Created #{time_ago_in_words(project.created_at)} ago" %> by
-            <% if project.user.id %>
             <%= link_to project.user.display_name, user_path(project.user) %>
-            <% else %>
-              anonymous
-            <% end %>
             </div>
             <div>
             <div class="row">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -144,6 +144,9 @@ if StaticPage.count == 0
   Rake::Task['db:import_pages'].invoke
 end
 
+# Create ghost user
+Rake::Task['user:create_anonymous'].invoke
+
 klasses.each_with_index do |klass, i|
   puts "#{klass.name}.count " + old_counts[i].to_s.bold.red + ' -> ' + klass.count.to_s.bold.green
 end

--- a/features/projects/deactive_owners.feature
+++ b/features/projects/deactive_owners.feature
@@ -9,3 +9,11 @@ Feature: List projects with deactivated users
     When I visit "/projects"
     Then I should see "Home run"
     And I should see "by Anonymous"
+
+  Scenario: You can view the default anonymous ("Ghost") user page
+    Given the anonymous user exists
+    And "Billy Bob" creates the project "Home run"
+    When "Billy Bob" deactivates his account
+    And I visit "/projects"
+    And I click "Anonymous"
+    Then I should be on the anonymous profile page

--- a/features/projects/deactive_owners.feature
+++ b/features/projects/deactive_owners.feature
@@ -8,4 +8,4 @@ Feature: List projects with deactivated users
     And "Billy Bob" deactivates his account
     When I visit "/projects"
     Then I should see "Home run"
-    And I should see "by anonymous"
+    And I should see "by Anonymous"

--- a/features/step_definitions/projects_steps.rb
+++ b/features/step_definitions/projects_steps.rb
@@ -213,3 +213,8 @@ Given(/^"([^"]*)" deactivates his account$/) do |name|
   user = User.find_by first_name: first_name, last_name: last_name
   user.delete
 end
+
+Given(/^the anonymous user exists$/) do
+  attributes = { id: -1, first_name: 'Anonymous', last_name: '', email: 'anonymous@example.org' }
+  FactoryBot.create(:user, attributes)
+end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -319,6 +319,10 @@ Given(/^I should be on the "([^"]*)" page for "(.*?)"$/) do |page, user|
   expect(current_path).to eq path_to(page, this_user)
 end
 
+Given(/^I should be on the anonymous profile page$/) do
+  expect(current_path).to eq('/users/-1')
+end
+
 Given(/^I (?:am on|go to|should be on) my "([^"]*)" page$/) do |page|
   page.downcase!
   if page == 'profile'

--- a/lib/tasks/create_anonymous_user.rake
+++ b/lib/tasks/create_anonymous_user.rake
@@ -1,0 +1,6 @@
+namespace :user do
+  desc 'Creates an anonymous user in an existing database'
+  task create_anonymous: :environment do
+    User.create! id: -1, first_name: 'Anonymous', last_name: '', email: 'anonymous@agileventures.org', password: 'temp1234'
+  end
+end


### PR DESCRIPTION
#### Description
Updated the null user class to have an id.

This allows removal of the conditional in the view, because the
<link_to> method can now render since the returned NullUser object has
an id.

We should create an anonymous/ghost user in production with an id of -1.
(See https://github.com/AgileVentures/WebsiteOne/pull/2588#discussion_r223558623 for why the id of -1 is being used rather than a positive id # that's currently not being used in production)

Fixes #2583

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This addition allows removal of code in the view.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tests already in place.


