### PR TITLE
Fix undefined method for nil class when viewing event show page

### DIFF
--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -32,6 +32,7 @@ class EventInstance < ApplicationRecord
 
   # margin: Seconds for which condition can be relaxed for start time
   def updated_within_current_event_duration?(margin)
+    return false unless event.current_start_time
     updated_at > (event.current_start_time - margin) &&
       updated_at < event.current_end_time
   end

--- a/features/events/show_event.feature
+++ b/features/events/show_event.feature
@@ -17,6 +17,12 @@ Feature: Show Events
       | Standup    | Daily standup meeting   | Scrum           | 2014/02/03 07:00:00 UTC | 150      | weekly  | UTC       |         | 15                                        | 1                     |
       | ClientMtg  | Daily client meeting    | ClientMeeting   | 2014/02/03 11:00:00 UTC | 150      | never   | UTC       |         |                                           |                       |
 
+  @javascript
+  Scenario: Event show page should display on the day of the event given the event already occurred
+    Given the date is "2018/09/05 09:15:00 UTC"
+    Given "Billy" created the "CS169 - HW2" event with an event instance "CS169"
+    When they view the event "CS169 - HW2"
+    Then I am on the show page for event "CS169 - HW2"
 
   @javascript
   Scenario: Event show page shows creator's icon, links to creator's profile, and date created

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -99,6 +99,12 @@ When(/^the next event should be in:$/) do |table|
   end
 end
 
+Given(/^"([^"]*)" created the "([^"]*)" event with an event instance "([^"]*)"$/) do |user_name, event_name, event_instance_name|
+  user = User.find_by(first_name: user_name)
+  event = Event.create!(name: event_name, category: "PairProgramming", description: "Pairing together", repeats: "never", repeats_every_n_weeks: 1, repeats_weekly_each_days_of_the_week_mask: 0, repeat_ends: true, time_zone: "UTC", created_at: "2018-09-05 00:49:47", updated_at: "2018-09-05 04:12:15", start_datetime: "2018-09-06 07:00:00", duration: 30, creator_id: user.id)
+  EventInstance.create!(event_id: event.id, title: event_instance_name, hangout_url: "https://hangouts.google.com/call/BxivVrWsi_HEyfRVa...", created_at: "2018-09-05 03:22:02", updated_at: "2018-09-05 03:30:20", category: "PairProgramming", url_set_directly: true, yt_video_id: "hx7c0P0qKWc")
+end
+
 Given(/^I am on the show page for event "([^"]*)"$/) do |name|
   event = Event.find_by_name(name)
   visit event_path(event)


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
When an event exists before the actual event start date the event occurrence method is returning nil.
This is happening when a user creates an event and starts a hangout, but then after the hangout finishes the event is edited (most likely no one showed and so they reschedule) to start at a later date. 

Fixes #2603, Fixes #2233, and Fixes #2043
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is to address airbrake issue for an undefined method on nil class error

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added spec to catch the undefined method :- for nil object.

The event show page will issue a 500 internal error due to an event
instance existing before the actual event start date.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
