### PR TITLE
Remove default PaperTrail config

### DIFF
--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,0 @@
-PaperTrail.config.track_associations = false


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Removed associations tracking config setting, because it is now the
default setting due to the associations tracking utility is now a
seperate gem.

Fixes #2623 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To clean up test output.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests passing locally
