### PR TITLE
Better spacing between embedded video and video links

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,7 +37,10 @@
 .video-container {
   position: relative;
   padding-bottom: 56.25%;
-  padding-top: 30px; height: 0; overflow: hidden;
+  padding-top: 30px; 
+  height: 0; 
+  overflow: hidden;
+  margin-bottom: 50px;
 }
 
 .video-container iframe,


### PR DESCRIPTION
Fixes #2682 spacing between embedded video and video links. 

#### Description
Add margin below embedded video to add spacing between video and links

#### Motivation and Context

This change is required to fix spacing issue on profile page.
https://github.com/AgileVentures/WebsiteOne/issues/2682

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
