### PR TITLE
Make event drop down show only active projects

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   def index
     @users = users
     @users_count = @users.total_count
-    @projects = Project.where(status: "Active").sort { |a, b| a.title <=> b.title }
+    @projects = Project.where(status: "active").sort { |a, b| a.title <=> b.title }
     @user_type = params[:title].blank? ? 'Volunteer' : params[:title]
     @user_type = 'Premium Member' if params[:title] == 'Premium'
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
   def index
     @users = users
     @users_count = @users.total_count
-    @projects = Project.all.sort { |a, b| a.title <=> b.title }
+    @projects = Project.where(status: "Active").sort { |a, b| a.title <=> b.title }
     @user_type = params[:title].blank? ? 'Volunteer' : params[:title]
     @user_type = 'Premium Member' if params[:title] == 'Premium'
 
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    if should_display_user?(@user) 
+    if should_display_user?(@user)
       @event_instances = EventInstance.where(user_id: @user.id)
                              .order(created_at: :desc).limit(5)
       set_activity_tab(params[:tab])

--- a/features/step_definitions/event_steps.rb
+++ b/features/step_definitions/event_steps.rb
@@ -439,15 +439,10 @@ end
 
 Then(/^the dropdown with id "(.*)" should only have active projects$/) do |select_id|
   # Write code here that turns the phrase above into concrete actions
-  active_projects = Project.active
-  non_active_projects = Project.all - active_projects
-  # page.select project_name, from: "project_id"
-  within "##{select_id}" do
-    active_projects.pluck(:title).each do |title|
-      expect(page).to have_content(title)
+    Project.active.pluck(:title).each do |title|
+      expect(page).to have_css("##{select_id}", :text => title, visible: false)
     end
-    non_active_projects.pluck(:title).each do |title|
-      expect(page).to have_no_content(title)
+    Project.where.not(status: 'active').pluck(:title).each do |title|
+      expect(page).to_not have_css("##{select_id}", :text => title, visible: false)
     end
-  end
 end

--- a/features/users/user_list.feature
+++ b/features/users/user_list.feature
@@ -36,6 +36,11 @@ Feature: List Users
     And I should see "5" user avatars within the main content
     And I should see "Check out our 5 awesome volunteers from all over the globe!"
 
+  Scenario: Project dropdown on users page has only active projects
+    When I click "Members" within the navbar
+    Then I should be on the "our members" page
+    And the dropdown with id "project_filter" should only have active projects
+
   Scenario: Paginate the User list
     Given there are an extra 15 users
     And I am on the members page


### PR DESCRIPTION
fixes #1811 

<!--- Provide a general summary of your changes in the Title above -->
Make project dropdown only show active projects on volunteers page
#### Description
<!--- Describe your changes in detail -->
Filter only active projects to be displayed on the projects dropdown
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To reduce the number of projects displaved on the dropdown
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I havent writen acceptance tests yet, but I have tested manually on the UI
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Fixes #1811 