### PR TITLE
Removed rack-timeout from development env, fixes 2686

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,9 +119,10 @@ group :development, :test do
   gem 'rspec-html-matchers'
   gem 'rspec-rails'
   gem 'simplecov', '~> 0.16.1'
+  gem 'rdoc'
 end
 
-group :development, :staging, :production do
+group :staging, :production do
   gem 'rack-timeout'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,6 @@ group :development, :test do
   gem 'rspec-html-matchers'
   gem 'rspec-rails'
   gem 'simplecov', '~> 0.16.1'
-  gem 'rdoc'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,7 +486,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rdoc (6.0.4)
     recaptcha (4.12.0)
       json
     redcarpet (3.4.0)
@@ -732,7 +731,6 @@ DEPENDENCIES
   rails-controller-testing (~> 1.0, >= 1.0.2)
   rails_12factor
   rails_autolink (~> 1.1.6)
-  rdoc
   recaptcha
   redcarpet
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,6 +486,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rdoc (6.0.4)
     recaptcha (4.12.0)
       json
     redcarpet (3.4.0)
@@ -731,6 +732,7 @@ DEPENDENCIES
   rails-controller-testing (~> 1.0, >= 1.0.2)
   rails_12factor
   rails_autolink (~> 1.1.6)
+  rdoc
   recaptcha
   redcarpet
   rspec
@@ -768,4 +770,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.16.6


### PR DESCRIPTION
fixes #2686
Removed rack-timeout from development env - now it's possible to use pry and byebug
In my opinion we should not use it in development anyway. From rack-timeout documentation:

> Rack::Timeout is not a solution to the problem of long-running requests, it's a debug and remediation tool. App developers should track rack-timeout's data and address recurring instances of particular timeouts, for example by refactoring code so it runs faster or offsetting lengthy work to happen asynchronously.

Also added rdoc gem to Gemfile, Without this I could not install this app locally on linux manjaro due to missing `rdoc/markdown/to_html` file.  
