### PR TITLE
switch github user name and github repo name to return the correct results#2576

### DIFF
--- a/app/jobs/github_languages_job.rb
+++ b/app/jobs/github_languages_job.rb
@@ -12,7 +12,7 @@ module GithubLanguagesJob
   end
 
   def run
-    Project.with_github_url.each do |project| 
+    Project.with_github_url.each do |project|
       begin
         add_new_languages_to(project)
       rescue StandardError => error
@@ -26,7 +26,7 @@ module GithubLanguagesJob
   end
 
   def github_languages_for(project)
-    languages = client.languages("#{project.github_repo_name}/#{project.github_repo_user_name}")
+    languages = client.languages("#{project.github_repo_user_name}/#{project.github_repo_name}")
     languages.to_hash.keys
   end
 
@@ -39,6 +39,6 @@ module GithubLanguagesJob
   end
 
   def log_error(error, project)
-    ErrorLoggingService.new(error).log("Updating the languages for #{project.github_url} may have caused the issue!") 
+    ErrorLoggingService.new(error).log("Updating the languages for #{project.github_url} may have caused the issue!")
   end
 end


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
These methods return the opposite of what they say they return, so github_repo_name actually returns the github_repo_user_name and vice versa.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to call the methods in the reverse order because what they return is not consistent with their naming

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
