### PR TITLE
Append error message to array

### DIFF
--- a/lib/validators/image_url_validator.rb
+++ b/lib/validators/image_url_validator.rb
@@ -11,11 +11,11 @@ class ImageUrlValidator < ActiveModel::Validator
     
     if record.image_url.present?
       if invalid_format?(record.image_url)
-        record.errors.messages[:image_url] = 'Invalid format. Image must be png, jpg, or jpeg.'
+        record.errors.messages[:image_url] << 'Invalid format. Image must be png, jpg, or jpeg.'
       end
 
-      unless is_image_host_whitelisted?(record.image_url) 
-        record.errors.messages[:image_url] = 'Invalid image url. Image provider not found in provider whitelist.'
+      unless is_image_host_whitelisted?(record.image_url)
+        record.errors.messages[:image_url] << 'Invalid image url. Image provider not found in provider whitelist.'
       end
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -36,6 +36,11 @@ describe Project, type: :model do
       expect(subject).to_not be_valid
     end
 
+    it 'should not crash the website with an invalid image url ' do
+      subject.image_url = 'https://www.flickr.com/photos/63977906@N00'
+      expect(subject).to_not be_valid
+    end
+
     it 'should not accept invalid github url' do
       subject.source_repositories.create(url: 'https:/github.com/google/instant-hangouts')
       expect(subject).to_not be_valid


### PR DESCRIPTION
## Description

The messages hash has a value listing all errors in an array. Updated
Image validator to append error messages to the array instead of over
writing the array with a String. This is being done because it causes
Rails ActiveRecord to error out when it does post validation checks,
because it's expecting an array, but instead receives a String.

Fixes #2857
