### PR TITLE
Add event slack channels

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,9 +1,11 @@
 class Event < ApplicationRecord
   has_many :event_instances
   belongs_to :project
+  belongs_to :creator, class_name: 'User'
+  has_and_belongs_to_many :slack_channels
+  
   serialize :exclusions
 
-  belongs_to :creator, class_name: 'User'
 
   extend FriendlyId
   friendly_id :name, use: :slugged
@@ -269,6 +271,10 @@ class Event < ApplicationRecord
 
   def modifier
     User.find modifier_id
+  end
+
+  def slack_channel_codes
+    slack_channels.pluck(:code)
   end
 
   private

--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -64,7 +64,7 @@ class EventInstance < ApplicationRecord
     yt_video_id && "https://youtu.be/#{yt_video_id}"
   end
 
-  def channels_for_event
+  def channels_for_event event_id
     return [] if event_id.nil?
     event = Event.find(event_id)
     event.slack_channel_codes

--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -64,9 +64,9 @@ class EventInstance < ApplicationRecord
     yt_video_id && "https://youtu.be/#{yt_video_id}"
   end
 
-  def channels_for_event event_id
-    return [] if event_id.nil?
-    event = Event.find(event_id)
+  def channels_for_event
+    return [] if self.event_id.nil?
+    event = Event.find(self.event_id)
     event.slack_channel_codes
   end
 

--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -64,6 +64,12 @@ class EventInstance < ApplicationRecord
     yt_video_id && "https://youtu.be/#{yt_video_id}"
   end
 
+  def channels_for_event
+    return [] if event_id.nil?
+    event = Event.find(event_id)
+    event.slack_channel_codes
+  end
+
   private
 
   def manually_updated_event_not_finished?

--- a/app/models/slack_channel.rb
+++ b/app/models/slack_channel.rb
@@ -1,5 +1,5 @@
 class SlackChannel < ApplicationRecord
 
 has_and_belongs_to_many :projects
-
+has_and_belongs_to_many :events
 end

--- a/app/services/hangout_notification_service.rb
+++ b/app/services/hangout_notification_service.rb
@@ -22,6 +22,7 @@ class HangoutNotificationService
     return if @event_instance.hangout_url.blank?
     
     channels = channels_for_project @event_instance.project
+    channels += channels_for_event @event_instance.event_id
     message = "#{@event_instance.title}: <#{@event_instance.hangout_url}|click to join>"
     @here_message = "@here #{message}"
     @channel_message = "@channel #{message}"
@@ -33,6 +34,13 @@ class HangoutNotificationService
     return [] if project.nil? or project.slug.nil?
     project.slack_channel_codes
   end
+
+  def channels_for_event event_id
+    return [] if event_id.nil?
+    event = Event.find(event_id)
+    event.slack_channel_codes
+  end
+
   
   def send_notifications channels
     return post_premium_mob_hangout_notification if @event_instance.for == 'Premium Mob Members'

--- a/app/services/hangout_notification_service.rb
+++ b/app/services/hangout_notification_service.rb
@@ -22,7 +22,7 @@ class HangoutNotificationService
     return if @event_instance.hangout_url.blank?
     
     channels = channels_for_project @event_instance.project
-    channels += channels_for_event @event_instance.event_id
+    channels += @event_instance.channels_for_event @event_instance.event_id
     message = "#{@event_instance.title}: <#{@event_instance.hangout_url}|click to join>"
     @here_message = "@here #{message}"
     @channel_message = "@channel #{message}"
@@ -35,13 +35,6 @@ class HangoutNotificationService
     project.slack_channel_codes
   end
 
-  def channels_for_event event_id
-    return [] if event_id.nil?
-    event = Event.find(event_id)
-    event.slack_channel_codes
-  end
-
-  
   def send_notifications channels
     return post_premium_mob_hangout_notification if @event_instance.for == 'Premium Mob Members'
     case @event_instance.category

--- a/app/services/hangout_notification_service.rb
+++ b/app/services/hangout_notification_service.rb
@@ -22,7 +22,7 @@ class HangoutNotificationService
     return if @event_instance.hangout_url.blank?
     
     channels = channels_for_project @event_instance.project
-    channels += @event_instance.channels_for_event @event_instance.event_id
+    channels += @event_instance.channels_for_event
     message = "#{@event_instance.title}: <#{@event_instance.hangout_url}|click to join>"
     @here_message = "@here #{message}"
     @channel_message = "@channel #{message}"

--- a/app/services/youtube_notification_service.rb
+++ b/app/services/youtube_notification_service.rb
@@ -19,7 +19,7 @@ class YoutubeNotificationService
     return unless Features.slack.notifications.enabled
     return if @event_instance.yt_video_id.blank?
     channels = channels_for_project @event_instance.project
-    channels += @event_instance.channels_for_event 
+    channels += @event_instance.channels_for_event @event_instance.event_id
     
     video = "https://youtu.be/#{@event_instance.yt_video_id}"
     @yt_message = "Video/Livestream: <#{video}|click to play>"

--- a/app/services/youtube_notification_service.rb
+++ b/app/services/youtube_notification_service.rb
@@ -19,8 +19,8 @@ class YoutubeNotificationService
     return unless Features.slack.notifications.enabled
     return if @event_instance.yt_video_id.blank?
     channels = channels_for_project @event_instance.project
-    channels += channels_for_event @event_instance.event_id
-
+    channels += @event_instance.channels_for_event 
+    
     video = "https://youtu.be/#{@event_instance.yt_video_id}"
     @yt_message = "Video/Livestream: <#{video}|click to play>"
 
@@ -30,12 +30,6 @@ class YoutubeNotificationService
   def channels_for_project project 
     return [] if project.nil? or project.slug.nil?
     project.slack_channel_codes
-  end
-
-  def channels_for_event event_id
-    return [] if event_id.nil?
-    event = Event.find(event_id)
-    event.slack_channel_codes
   end
 
   def send_notifications channels 

--- a/app/services/youtube_notification_service.rb
+++ b/app/services/youtube_notification_service.rb
@@ -19,7 +19,7 @@ class YoutubeNotificationService
     return unless Features.slack.notifications.enabled
     return if @event_instance.yt_video_id.blank?
     channels = channels_for_project @event_instance.project
-    channels += @event_instance.channels_for_event @event_instance.event_id
+    channels += @event_instance.channels_for_event
     
     video = "https://youtu.be/#{@event_instance.yt_video_id}"
     @yt_message = "Video/Livestream: <#{video}|click to play>"

--- a/app/services/youtube_notification_service.rb
+++ b/app/services/youtube_notification_service.rb
@@ -19,6 +19,7 @@ class YoutubeNotificationService
     return unless Features.slack.notifications.enabled
     return if @event_instance.yt_video_id.blank?
     channels = channels_for_project @event_instance.project
+    channels += channels_for_event @event_instance.event_id
 
     video = "https://youtu.be/#{@event_instance.yt_video_id}"
     @yt_message = "Video/Livestream: <#{video}|click to play>"
@@ -29,6 +30,12 @@ class YoutubeNotificationService
   def channels_for_project project 
     return [] if project.nil? or project.slug.nil?
     project.slack_channel_codes
+  end
+
+  def channels_for_event event_id
+    return [] if event_id.nil?
+    event = Event.find(event_id)
+    event.slack_channel_codes
   end
 
   def send_notifications channels 

--- a/db/migrate/20190412143519_create_join_table_events_slack_channel.rb
+++ b/db/migrate/20190412143519_create_join_table_events_slack_channel.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableEventsSlackChannel < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :events, :slack_channels do |t|
+      t.index [:event_id, :slack_channel_id], name: "slack_event_channel", unique: true
+      t.index [:slack_channel_id, :event_id], name: "slack_channel_name_event", unique: true
+    end
+  end
+end

--- a/lib/channels_list.rb
+++ b/lib/channels_list.rb
@@ -58,7 +58,8 @@ module ChannelsList
       'pairing_notifications': 'C29J3DPGW',
       'standup_notifications': 'C29JE6HGR',
       'premium_extra': 'C29J4QQ9M',
-      'premium_mob_trialists': 'C29J4QQ9F'
+      'premium_mob_trialists': 'C29J4QQ9F',
+      'new-members': 'C02G8J699'
     }
     GITTER_ROOMS = {
       'saasbook/MOOC': '56b8bdffe610378809c070cc',

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -590,4 +590,13 @@ describe Event, :type => :model do
       end
     end
   end
+
+  context '#slack_channel_codes' do
+    context 'default' do
+      it 'should return an empty array' do
+        event = FactoryBot.build(:event, name: 'Event without slack channel associated')
+        expect(event.slack_channel_codes).to eq []
+      end
+    end
+  end
 end

--- a/spec/services/hangout_notification_service_spec.rb
+++ b/spec/services/hangout_notification_service_spec.rb
@@ -90,6 +90,16 @@ describe HangoutNotificationService do
     let(:multiple_channel_hangout) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: multiple_channel_project, for: '' }
     let(:event_instance_with_event_slack_channels) { mock_model EventInstance, title: 'MockEvent', category: "PairProgramming", hangout_url: "mock_url", user: user, project: websiteone_project, for: '', event_id: event_with_slack_channels.id }
     
+    before do
+      allow(websiteone_hangout).to receive(:channels_for_event).and_return([])
+      allow(no_project_hangout).to receive(:channels_for_event).and_return([])
+      allow(project_with_no_slack_hangout).to receive(:channels_for_event).and_return([])
+      allow(cs169_hangout).to receive(:channels_for_event).and_return([])
+      allow(missing_url_hangout).to receive(:channels_for_event).and_return([])
+      allow(multiple_channel_hangout).to receive(:channels_for_event).and_return([])
+      allow(event_instance_with_event_slack_channels).to receive(:channels_for_event).and_return(['C02G8J699'])
+    end
+
     context 'PairProgramming' do
       
       it 'sends the correct slack message to the correct channels when associated with a project' do
@@ -190,6 +200,8 @@ describe HangoutNotificationService do
       let(:general_channel_id) { 'C0TLAE1MH' }
       let(:pairing_notifications_channel_id) { 'C29J3DPGW' }
       let(:websiteone_channel_id) { 'C29J4QQ9W' }
+      
+      before { allow(premium_mob_hangout).to receive(:channels_for_event).and_return([]) }
       
       it 'posts hangout url to appropriate private channels' do
         expect(slack_client).to receive(:chat_postMessage).with(post_premium_mob_notification_post_args).once

--- a/spec/services/youtube_notification_service_spec.rb
+++ b/spec/services/youtube_notification_service_spec.rb
@@ -11,7 +11,8 @@ describe YoutubeNotificationService do
   let(:websiteone_channel_id) { 'C29J4QQ9W' }
   let(:premium_extra_channel_id) { 'C29J4QQ9M' }
   let(:premium_mob_trialists_channel_id) { 'C29J4QQ9F' }
-  
+  let(:new_members_channel_id) { 'C02G8J699' }
+
   describe '.post_yt_link' do
     let(:client) { spy(:slack_client) }
     
@@ -25,7 +26,9 @@ describe YoutubeNotificationService do
     end
     
     context('PairProgramming') do
-      let(:event_instance) { EventInstance.create(title: 'MockEvent', category: 'PairProgramming', hangout_url: 'mock_url', user: user ) }
+      let(:event_instance) { EventInstance.create(title: 'MockEvent', category: 'PairProgramming', hangout_url: 'mock_url', user: user, event_id: event_with_slack_channels.id ) }
+      let(:event_with_slack_channels) { FactoryBot.create(:event, slack_channels: Array(SlackChannel.create({ code: 'C02G8J699' }))) }
+      
       before { allow(event_instance).to receive(:for).and_return '' }
       
       it 'sends the correct slack message to the correct channels' do
@@ -36,6 +39,7 @@ describe YoutubeNotificationService do
         youtube_notification_service.with event_instance, client
         expect(client).to have_received(:chat_postMessage).with(expected_post_args.merge!(channel: general_channel_id))
         expect(client).to have_received(:chat_postMessage).with(expected_post_args.merge!(channel: websiteone_channel_id))
+        expect(client).to have_received(:chat_postMessage).with(expected_post_args.merge!(channel: new_members_channel_id))
       end
 
       it 'does not ping slack when the project is cs169' do


### PR DESCRIPTION
- Add associations
- Add join table migration
- Add models test
- refactor notification services tests

Co-authored-by: Gideon Kimutai <gideon.kimutai.kim@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne/issues  -->

fixes #3135 

#### Testing
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne/blob/develop/CONTRIBUTING.md#git-and-github-->
Not really happy with the youtubenotificationservice spec... 
the easiest thing to show proof of concept was to add it to an existing test entitled `sends the correct slack message to the correct channels`, but this does not help for others to understand what we are testing
also, I worry about having three expectations in the same it block... 
@tansaku please have a look and see what you think
we talked about a rake task to add event.slack_channels, but it's a bit different... I could come up with a hardcoded list of recurring events, which are not pinging the channels we expect?