### PR TITLE
Persist empty string when repeat end is set to never

### DIFF
--- a/app/assets/javascripts/event_datepicker.js
+++ b/app/assets/javascripts/event_datepicker.js
@@ -31,7 +31,7 @@ var eventDatepicker = {
         switch ($('#event_repeat_ends_string').val()) {
             case 'never':
                 $('#repeat_ends_on_label').hide();
-                $('#repeat_ends_on').hide();
+                $('#repeat_ends_on').hide().val('');
                 break;
             case 'on':
                 $('#repeat_ends_on_label').show();

--- a/spec/javascripts/event_datepicker_spec.js
+++ b/spec/javascripts/event_datepicker_spec.js
@@ -42,4 +42,12 @@ describe('eventDatePicker', function(){
     expect($('#repeat_ends_on')).toBeHidden();
   });
 
+  it('set repeat-ends-on to an empty string when it is set and changed to never', function () {
+    set_event_repeats_to_weekly();
+    $("#repeat_ends_on").val('2019-08-01')
+    set_event_repeat_ends_to_never();
+    expect($('#repeat_ends_on')).toBeHidden();
+    expect($('#repeat_ends_on_label')).toBeHidden();
+    expect($('#repeat_ends_on').val()).toEqual('');
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue addressed
Fix UI bug when repeat end is set to never on the UI
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne/issues  -->

[Fixes #3215](https://github.com/AgileVentures/WebsiteOne/issues/3215)

#### Screenshots (if appropriate):
<!-- please include screenshots of any changes to the UI for quick review  -->
<!-- please show how things look on both desktop and mobile  -->

#### Testing
N/A

<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne/blob/develop/CONTRIBUTING.md#git-and-github-->
