### PR TITLE
Remove obsolete methods

### DIFF
--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -1,6 +1,5 @@
 class EventInstancesController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :cors_preflight_check, except: [:index, :edit, :update_link]
   before_action :authenticate_user!, only: [:edit, :update_link, :update]
 
   def update
@@ -84,28 +83,10 @@ class EventInstancesController < ApplicationController
     params.require(:event_instance).permit(:yt_video_id, :hoa_status)
   end
 
-  def cors_preflight_check
-    head :bad_request and return unless (allowed? || local_request?)
-
-    set_cors_headers
-    head :ok and return if request.method == 'OPTIONS'
-  end
-
-  def allowed?
-    allowed_sites = %w(a-hangout-opensocial.googleusercontent.com)
-    origin = request.env['HTTP_ORIGIN']
-    allowed_sites.any? { |url| origin =~ /#{url}/ }
-  end
-
   def local_request?
     request.env['HTTP_ORIGIN'].include?(request.env['HTTP_HOST'])
   rescue
     true
-  end
-
-  def set_cors_headers
-    response.headers['Access-Control-Allow-Origin'] = request.env['HTTP_ORIGIN']
-    response.headers['Access-Control-Allow-Methods'] = 'PUT'
   end
 
   def check_and_transform_params(event_instance)

--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -104,7 +104,7 @@ class EventInstancesController < ApplicationController
         category: params[:category],
         user_id: params[:host_id],
         hangout_participants_snapshots_attributes: [{participants: params[:participants]}],
-        participants: merge_participants(event_instance.participants, params[:participants]),
+        participants: params[:participants],
         hangout_url: params[:hangout_url],
         yt_video_id: YouTubeRails.extract_video_id(params[:yt_url]) || params[:yt_video_id],
         hoa_status: params[:hoa_status],
@@ -112,16 +112,5 @@ class EventInstancesController < ApplicationController
         updated_at: Time.now,
         youtube_tweet_sent: params[:you_tube_tweet_sent]
     ).permit!
-  end
-
-  def merge_participants(existing_participants, new_participants)
-    return new_participants unless existing_participants
-    return existing_participants unless new_participants
-    new_participants.each do |_, v|
-      unless existing_participants.values.any? { |struc| struc['person']['id'] == v['person']['id'] }
-        existing_participants[existing_participants.length.to_s] = v
-      end
-    end
-    return existing_participants
   end
 end

--- a/spec/controllers/event_instances_controller_spec.rb
+++ b/spec/controllers/event_instances_controller_spec.rb
@@ -139,26 +139,4 @@ describe EventInstancesController do
       end
     end
   end
-
-  describe 'CORS handling' do
-    it 'drops request if the origin is not allowed' do
-      allow(controller).to receive(:allowed?).and_return(false)
-      get :update, params: params
-      expect(response.status).to eq(400)
-    end
-
-    it 'sets CORS headers' do
-      headers = { 'Access-Control-Allow-Origin' => 'http://test.com',
-                  'Access-Control-Allow-Methods' => 'PUT' }
-      request.headers.merge!(headers)
-      get :update, params: params
-      expect(response.headers.to_h).to include(headers)
-    end
-
-    it 'responses OK on preflight check' do
-      allow(controller).to receive(:authenticate_user!).and_return(true)
-      get :update, params: params
-      expect(response.status).to eq(200)
-    end
-  end
 end


### PR DESCRIPTION
## Description
These methods were causing code climate issues, and they're actually no longer needed as we're not receiving telemetry data from google anymore. 

Fixes #3226 