### PR TITLE
Remove destroy action from Project Controller

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,7 @@
 class ProjectsController < ApplicationController
   layout 'with_sidebar'
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_project, only: [:show, :edit, :update, :destroy]
+  before_action :set_project, only: [:show, :edit, :update]
   before_action :get_current_stories, only: [:show]
   include DocumentsHelper
 
@@ -53,15 +53,6 @@ class ProjectsController < ApplicationController
       flash.now[:alert] = 'Project was not updated.'
       render 'edit'
     end
-  end
-
-  def destroy
-    #if @project.destroy
-    #  @notice = 'Project was successfully deleted.'
-    #else
-    #  @notice = 'Project was not successfully deleted.'
-    #end
-    #redirect_to projects_path, notice: @notice
   end
 
   def follow

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
   resources :event_instances, :only => [:edit]
   patch '/event_instances/:id', to: 'event_instances#update_link'
 
-  resources :projects, :format => false do
+  resources :projects, except: [:destroy], :format => false do
     member do
       put :mercury_update
       get :mercury_saved

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -184,44 +184,6 @@ describe ProjectsController, :type => :controller do
       end
     end
 
-    #  Scenarios for DESTROY action commented out until this functionality is needed
-    #describe '#destroy' do
-    #  before :each do
-    #    @project = double(Project)
-    #    Project.stub(:find).and_return(@project)
-    #  end
-    #  it 'receives destroy call' do
-    #    expect(@project).to receive(:destroy)
-    #    delete :destroy, id: 'test'
-    #  end
-    #
-    #  context 'on successful delete' do
-    #    before(:each) do
-    #      @project.stub(:destroy).and_return(true)
-    #      delete :destroy, id: 'test'
-    #    end
-    #    it 'redirects to index' do
-    #      expect(response).to redirect_to(projects_path)
-    #    end
-    #    it 'shows the correct message' do
-    #      expect(flash[:notice]).to eq 'Project was successfully deleted.'
-    #    end
-    #  end
-    #
-    #  context 'on unsuccessful delete' do
-    #    before do
-    #      @project.stub(:destroy).and_return(false)
-    #      delete :destroy, id: 'test'
-    #    end
-    #    it 'redirects to index' do
-    #      expect(response).to redirect_to(projects_path)
-    #    end
-    #    it 'shows the correct message' do
-    #      expect(flash[:notice]).to eq 'Project was not successfully deleted.'
-    #    end
-    #  end
-    #end
-
     describe '#update' do
       before(:each) do
         @project = FactoryBot.create(:project)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This pull request removes destroy action from projects controller since it is not been used.
 - Delete commented test
-  exempt destroy routes

#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne/issues  -->

fixes #[2968](https://github.com/AgileVentures/WebsiteOne/issues/2968)

#### Screenshots (if appropriate):
<!-- please include screenshots of any changes to the UI for quick review  -->
<!-- please show how things look on both desktop and mobile  -->
N/A

#### Testing
N/A
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne/blob/develop/CONTRIBUTING.md#git-and-github-->
