### PR TITLE
Set Codeclimate duplicate and similar code threshold to 3

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,12 @@
 ---
 version: "2"
+checks:
+  similar-code:
+    enabled: true
+    config:
+      threshold: 3
+      languages:
+      - ruby
 plugins:
   brakeman:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,41 +1,38 @@
 ---
-engines:
+version: "2"
+checks:
+  similar-code:
+    enabled: true
+    config:
+      threshold: 3
+      languages:
+      - ruby
+      - javascript
+      - python
+      - php
+  identical-code:
+    enabled: true
+    config:
+      threshold: 3
+      languages:
+      - ruby
+      - javascript
+      - python
+      - php
+plugins:
   brakeman:
     enabled: true
   bundler-audit:
     enabled: true
   coffeelint:
     enabled: true
-  duplication:
-    enabled: true
-    config:
-      languages:
-      - ruby
-      - javascript
-      - python
-      - php
   eslint:
     enabled: true
   fixme:
     enabled: true
   rubocop:
     enabled: true
-ratings:
-  paths:
-  - Gemfile.lock
-  - "**.erb"
-  - "**.haml"
-  - "**.rb"
-  - "**.rhtml"
-  - "**.slim"
-  - "**.coffee"
-  - "**.inc"
-  - "**.js"
-  - "**.jsx"
-  - "**.module"
-  - "**.php"
-  - "**.py"
-exclude_paths:
+exclude_patterns:
 - config/
 - db/
 - features/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,12 +1,10 @@
 ---
 version: "2"
 checks:
+  identical-code:
+    enabled: false
   similar-code:
-    enabled: true
-    config:
-      threshold: 3
-      languages:
-      - ruby
+    enabled: false
 plugins:
   brakeman:
     enabled: true
@@ -14,6 +12,12 @@ plugins:
     enabled: true
   coffeelint:
     enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        ruby:
+          count_threshold: 3
   eslint:
     enabled: true
   fixme:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,24 +1,5 @@
 ---
 version: "2"
-checks:
-  similar-code:
-    enabled: true
-    config:
-      threshold: 3
-      languages:
-      - ruby
-      - javascript
-      - python
-      - php
-  identical-code:
-    enabled: true
-    config:
-      threshold: 3
-      languages:
-      - ruby
-      - javascript
-      - python
-      - php
 plugins:
   brakeman:
     enabled: true


### PR DESCRIPTION
Updated to [version 2](https://docs.codeclimate.com/docs/advanced-configuration#section-analysis-configuration-versions) used in Codeclimate, which allows tunable duplicate code checks.
WIP b/c I'm not sure how to test this w/o an open source project and need to tune the exact values of various `threshold` constants.

<!--- Provide a general summary of your changes in the Title above -->

#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne/issues  -->

fixes #2976

#### Screenshots (if appropriate):
<!-- please include screenshots of any changes to the UI for quick review  -->
<!-- please show how things look on both desktop and mobile  -->

#### Testing
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne/blob/develop/CONTRIBUTING.md#git-and-github-->
