### PR TITLE
Maintenance

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,6 +24,7 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
+    channel: rubocop-0-77
 exclude_patterns:
 - config/
 - db/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.5
   DisabledByDefault: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-performance
+require:
+  - rubocop-performance
+  - rubocop-rails
 
 AllCops:
   TargetRubyVersion: 2.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ require:
 AllCops:
   TargetRubyVersion: 2.5
   DisabledByDefault: true
+  Exclude:
+    - app/models/user.rb
+    - lib/validators/uri_validator.rb
 
 #################### Lint ################################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,7 +90,7 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: "Don't suppress exception."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: true
@@ -143,7 +143,7 @@ Lint/ShadowingOuterLocalVariable:
                  for block arguments or block local variables.
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Description: 'Checks for Object#to_s usage in string interpolation.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-to-s'
   Enabled: true
@@ -152,7 +152,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.
@@ -225,7 +225,7 @@ Metrics/CyclomaticComplexity:
                  of test cases needed to validate a method.
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: false
@@ -286,7 +286,7 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: true
 
-Performance/Sample:
+Style/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Fixnum]`.
@@ -376,20 +376,20 @@ Style/Alias:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
   Enabled: false
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Description: >-
                  Align the elements of an array literal if they span more than
                  one line.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays'
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Description: >-
                  Align the elements of a hash literal if they span more than
                  one line.
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: >-
                  Align the parameters of a method call if they span more
                  than one line.
@@ -675,13 +675,13 @@ Layout/IndentationWidth:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: false
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   Description: >-
                  Checks the indentation of the first element in an array
                  literal.
   Enabled: false
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: false
 
@@ -1064,7 +1064,7 @@ Layout/Tab:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: false
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Description: 'Checks trailing blank lines and final newline.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
   Enabled: false
@@ -1096,11 +1096,11 @@ Style/UnlessElse:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-else-with-unless'
   Enabled: false
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: false
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-q'
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -229,7 +229,7 @@ Metrics/CyclomaticComplexity:
                  of test cases needed to validate a method.
   Enabled: true
 
-Layout/LineLength:
+Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ group :test do
   gem 'puffing-billy', '~> 2.2.0'
   gem 'rails-controller-testing', '~> 1.0', '>= 1.0.2'
   gem 'rubocop-performance', '~> 1.5', '>= 1.5.2'
+  gem 'rubocop-rails', '~> 2.5', '>= 2.5.2'
   gem 'rubocop-rspec', '>=1.28'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :test do
   gem 'poltergeist'
   gem 'puffing-billy', '~> 2.2.0'
   gem 'rails-controller-testing', '~> 1.0', '>= 1.0.2'
+  gem 'rubocop-performance', '~> 1.5', '>= 1.5.2'
   gem 'rubocop-rspec', '>=1.28'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,6 +581,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
+    rubocop-rails (2.5.2)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     rubocop-rspec (1.37.1)
       rubocop (>= 0.68.1)
     ruby-gitter (0.1.0)
@@ -800,6 +804,7 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-rails
   rubocop-performance (~> 1.5, >= 1.5.2)
+  rubocop-rails (~> 2.5, >= 2.5.2)
   rubocop-rspec (>= 1.28)
   ruby-gitter
   sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,6 +579,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.5.2)
+      rubocop (>= 0.71.0)
     rubocop-rspec (1.37.1)
       rubocop (>= 0.68.1)
     ruby-gitter (0.1.0)
@@ -797,6 +799,7 @@ DEPENDENCIES
   rspec-activemodel-mocks
   rspec-html-matchers
   rspec-rails
+  rubocop-performance (~> 1.5, >= 1.5.2)
   rubocop-rspec (>= 1.28)
   ruby-gitter
   sass-rails

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -96,10 +96,10 @@ class DocumentsController < ApplicationController
     valid_category = Document.find_by_id(new_parent_id)
     if valid_category
       @document.parent_id = valid_category.id
-      flash[:notice] = "You have successfully moved #{@document.title} to the #{valid_category.title} section." if @document.save
+      flash[:notice] = "You have successfully moved #{@document.title} to the #{valid_category.title} section."
     else
       flash[:error] = "Could not find the new parent document"
-		end
+    end
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -95,7 +95,7 @@ class DocumentsController < ApplicationController
   def change_document_parent(new_parent_id)
     valid_category = Document.find_by_id(new_parent_id)
     if valid_category
-      @document.parent_id = valid_category.id
+      @document.update!(parent_id: new_parent_id)
       flash[:notice] = "You have successfully moved #{@document.title} to the #{valid_category.title} section."
     else
       flash[:error] = "Could not find the new parent document"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,7 +79,7 @@ class UsersController < ApplicationController
   def users
     users = User.page(params[:page]).per(15)
         .includes(:status, :titles, :karma)
-        .filter(set_filter_params)
+        .param_filter(set_filter_params)
         .order("karmas.total DESC")
 
     users = users.allow_to_display unless privileged_visitor?

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -2,7 +2,7 @@ module Filterable
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def filter(filtering_params)
+    def param_filter(filtering_params)
       results = self.where(nil)
       filtering_params.each do |key, value|
         results = results.public_send(key, value) if value.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
       user.country_code = geo.data['country_code']
     end
   end
-  
+
   PREMIUM_MOB_PLAN_AMOUNT = 2500
 
   acts_as_taggable_on :skills, :titles
@@ -185,7 +185,7 @@ class User < ApplicationRecord
   end
 
   def number_hangouts_started_with_more_than_one_participant
-    event_instances.select { |h| h.participants != nil && h.participants.to_unsafe_h.count > 1 }.count
+    event_instances.count { |h| h.participants != nil && h.participants.to_unsafe_h.count > 1 }
   end
 
   def activity

--- a/db/migrate/20140427074629_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20140427074629_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -9,7 +9,7 @@ class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]
     add_index :taggings,
       [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
       unique: true, name: 'taggings_idx'
-   end
+  end
 
   def self.down
     remove_index :tags, :name

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -9,7 +9,7 @@ describe DocumentsController do
       'user_id' => "#{user.id}"
   } }
   let(:valid_session) { {} }
-  let(:categories) do 
+  let(:categories) do
     [
     FactoryBot.create(:document, id: 555, project_id: document.project_id, parent_id: nil, title: "Title-1"),
     FactoryBot.create(:document, id: 556, project_id: document.project_id, parent_id: nil, title: "Title-2")
@@ -21,7 +21,7 @@ describe DocumentsController do
     @user = FactoryBot.create(:user)
     request.env['warden'].stub :authenticate! => user
     controller.stub :current_user => user
-    @document = FactoryBot.create(:document)
+    @document = FactoryBot.create(:document, title: "doc title")
     allow(@document).to receive(:create_activity)
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :article do
     sequence(:title) {|n| "Title #{n}"}
-    content { Faker::Lorem.paragraph(1) }
+    content { Faker::Lorem.paragraph(sentence_count: 1) }
     tag_list { [ 'Ruby' ] }
     slug { title.parameterize }
     user

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     display_profile { true }
     slug { "#{first_name} #{last_name}".parameterize }
     bio { Faker::Lorem.sentence }
-    skill_list { Faker::Lorem.words(4) }
+    skill_list { Faker::Lorem.words(number: 4) }
 
     after(:create) do |user, evaluator|
       create(:authentication, provider: 'gplus', uid: evaluator.gplus, user_id: user.id)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -235,7 +235,7 @@ describe User, type: :model do
     end
   end
 
-  describe '.filter' do
+  describe '.param_filter' do
     let(:params) { {} }
 
     context 'has filters' do
@@ -250,7 +250,7 @@ describe User, type: :model do
         @user2.stop_following @project
         params['project_filter'] = @project.id
 
-        results = User.filter(params).allow_to_display
+        results = User.param_filter(params).allow_to_display
 
         expect(results).to include(@user1)
         expect(results).not_to include(@user2)
@@ -258,7 +258,7 @@ describe User, type: :model do
     end
 
     context 'no filters' do
-      subject { User.filter(params).allow_to_display }
+      subject { User.param_filter(params).allow_to_display }
 
       before(:each) do
         FactoryBot.create(:user, first_name: 'Bob', created_at: 5.days.ago)


### PR DESCRIPTION
Did some maintenance to help keep the repo updated.
- Rename method

filter is a core ruby method, and this name was clashing with the core
ruby method.

- Update RuboCop cop names
- Performance cops have been moved to seperate gem.
- Require rubocop performance
- Require rubocop rails
- Update Faker deprecated arguments

I'm going to hold off on updating the Ruby version until we have finished migrating to semaphore v2.