### PR TITLE
Update Ruby version to 2.6.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6.3
   DisabledByDefault: true
   Exclude:
     - app/models/user.rb

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Test MyApp
+name: Test WebsiteOne
 agent:
   machine:
     type: e1-standard-2
@@ -20,7 +20,7 @@ blocks:
           commands:
             - checkout
             - sem-service start postgres 11
-            - sem-version ruby 2.5.1
+            - sem-version ruby 2.6.3
             - sudo -u postgres createuser -s semaphore
             - createdb -U postgres -h 0.0.0.0 websiteone_test
             - change-phantomjs-version 2.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.6.3
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update -qq && apt-get install -y build-essential \

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.1'
+ruby '2.6.3'
 
 gem 'rails', '5.2.3'
 gem 'acts-as-taggable-on'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -835,7 +835,7 @@ DEPENDENCIES
   zeus
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.2

--- a/docs/c9/install_notes.md
+++ b/docs/c9/install_notes.md
@@ -2,10 +2,10 @@
 
 ![](images/Screenshot%202016-05-25%2008.40.44.png)
 
-1a) install ruby 2.5.1
+1a) install ruby 2.6.3
 
 ```
-$ rvm install 2.5.1
+$ rvm install 2.6.3
 ```
 
 2) update the local software (all the linux packages on the c9 machine)

--- a/docs/ubuntu/ubuntu_14.04_manual_install_notes.md
+++ b/docs/ubuntu/ubuntu_14.04_manual_install_notes.md
@@ -56,7 +56,7 @@ source ~/.rvm/scripts/rvm
 
 ## Install ruby
 ```
-rvm install ruby-2.5.1
+rvm install ruby-2.6.3
 ```
 
 ## Clone the respository (after a fork)
@@ -66,7 +66,7 @@ git clone git@github.com:<your github handle>/WebsiteOne.git
 
 ## Generate rvm config files within project
 ```
-rvm use ruby-2.5.1@WebsiteOne --ruby-version --create
+rvm use ruby-2.6.3@WebsiteOne --ruby-version --create
 ```
 
 ## Install bundler


### PR DESCRIPTION
Updating Ruby to 2.6.3 so that we can upgrade to a newer Heroku stack. 
This is in preparation of updating to 2.7.2 - see PR #3640 
