### PR TITLE
Update mission_statement.md

### DIFF
--- a/docs/mission_statement.md
+++ b/docs/mission_statement.md
@@ -15,7 +15,6 @@ To get involved please contact Sam Joseph <sam@agileventures.org> or Thomas Ochm
 
 ### Resources
 - [Agile Ventures site](http://agileventures.org)
-- [WebsiteOne on waffle.io](https://waffle.io/AgileVentures/WebsiteOne)
 - [Staging & developers servers](https://github.com/AgileVentures/WebsiteOne/wiki/Current-staging-servers)
 - [Expanded Mission Statement](expanded_mission_statement.md)
 


### PR DESCRIPTION
### What
remove waffle.io link
### Why
Waffle.io closed down in 2019.
### Source
https://projectmanagernews.com/general/what-happened-to-waffle-io/
