### PR TITLE
Update seeds.rb:

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ old_counts = klasses.map(&:count)
 should_prompt = old_counts.min.positive?
 
 def get_country
-  country = File.readlines("#{Rails.root}spec/fixtures/country_codes.txt").sample
+  country = File.readlines("#{Rails.root}/spec/fixtures/country_codes.txt").sample
   code, name = country.chomp.split('|')
   @country = { country_name: name, country_code: code }
 end


### PR DESCRIPTION
- fix `country_codes.txt` location on `seeds.rb`

<!--- Provide a general summary of your changes in the Title above -->

When running `bundle exec rake db:setup` I have this error message:
```bash
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/yb_widyokarsono/Work/AgileVentures/WebsiteOnespec/fixtures/country_codes.txt
```

then I update `country_codes.txt` location on `seeds.rb`

#### Issue addressed
<!-- include `fixes #<issue-number>` -->
<!-- the relevant issue in https://github.com/AgileVentures/WebsiteOne/issues  -->

fixes #

#### Screenshots (if appropriate):
<!-- please include screenshots of any changes to the UI for quick review  -->
<!-- please show how things look on both desktop and mobile  -->

#### Testing
<!-- Remember you must see any new tests you created (or old ones you changed) -->
<!-- fail as well as pass in order to ensure they are working -->
<!-- Unsure how to test? - please see https://github.com/AgileVentures/WebsiteOne/blob/develop/CONTRIBUTING.md#git-and-github-->
