### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:2.6.3
+FROM ruby:3.0.0
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update -qq && apt-get install -y build-essential \
-    libpq-dev nodejs qt5-default libqt5webkit5-dev dos2unix \
+    libpq-dev nodejs npm qt5-default libqt5webkit5-dev dos2unix \
     gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
 
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,8 +4,8 @@ development: &dev
   database: websiteone_development
   url: <%= ENV['DB_URL'] || ""%>
   pool: 20
-  user: <%= ENV["POSTGRES_USER"] %>
-  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  username: <%= ENV["DATABASE_POSTGRESQL_USERNAME"] %>
+  password: <%= ENV["DATABASE_POSTGRESQL_PASSWORD"] %>
 test: &test
   <<: *dev
   database: websiteone_test

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,10 +2,10 @@ development: &dev
   adapter: postgresql
   encoding: unicode
   database: websiteone_development
-  host: <%= ENV['DB_HOST'] || ""%>
+  url: <%= ENV['DB_URL'] || ""%>
   pool: 20
-  username: <%= ENV["DATABASE_POSTGRESQL_USERNAME"] %>
-  password: <%= ENV["DATABASE_POSTGRESQL_PASSWORD"] %>
+  user: <%= ENV["POSTGRES_USER"] %>
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
 test: &test
   <<: *dev
   database: websiteone_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,21 @@ services:
     image: postgres
     volumes:
       - dbVolume:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: ${DATABASE_POSTGRESQL_USER}
+      POSTGRES_PASSWORD: ${DATABASE_POSTGRESQL_PASSWORD}
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"
+      - "8888:8888"
     depends_on:
       - db
     environment:
-      - DB_HOST=db
+      POSTGRES_USER: ${DATABASE_POSTGRESQL_USER}
+      POSTGRES_PASSWORD: ${DATABASE_POSTGRESQL_PASSWORD}
+      DB_URL: postgres://db:5432
     volumes:
       - .:/WebsiteOne
       - javascript_vendors:/WebsiteOne/vendor/assets/javascripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"
-      - "8888:8888"
     depends_on:
       - db
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - dbVolume:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: ${DATABASE_POSTGRESQL_USER}
+      POSTGRES_USERNAME: ${DATABASE_POSTGRESQL_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_POSTGRESQL_PASSWORD}
   web:
     build: .
@@ -15,8 +15,6 @@ services:
     depends_on:
       - db
     environment:
-      POSTGRES_USER: ${DATABASE_POSTGRESQL_USER}
-      POSTGRES_PASSWORD: ${DATABASE_POSTGRESQL_PASSWORD}
       DB_URL: postgres://db:5432
     volumes:
       - .:/WebsiteOne


### PR DESCRIPTION
This fixes the docker build and moves to ruby 3.0.0.  The need to move to ruby 3.0.0 was requested here https://github.com/AgileVentures/WebsiteOne/issues/3790 .  The Docker automated shell script, setup.sh, was failing to build the project.  This was tested on Linux.  

Basically, we had to make a change or two to the dockerfile itself and then to the database.yml in Rails.  This should continue to work the same for others who don't use Docker.

And now setup.sh and start.sh function as expected.  