### PR TITLE
Fix bug #3834 runSpec argument to use headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY vendor/assets/javascripts /WebsiteOne/assets/javascripts
 FROM base
 
 # To execute tests, install chromium
-RUN apt install -y chromium
+RUN apt install -y xvfb chromium chromium-driver
 
 RUN dos2unix scripts/copy_javascript_dependencies.js
 RUN yarn install

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -11,5 +11,5 @@
     "**/*jasmine-jquery.js",
     "**/*spec_helper.js"
   ],
-  "browser": "chrome"
+  "browser": "headlessChrome"
 }


### PR DESCRIPTION
Fix for https://github.com/AgileVentures/WebsiteOne/issues/3834. This seems to work for me now when I run:

npx jasmine-browser-runner runSpec