### PR TITLE
Disable email signups to avoid bots

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,7 @@ features:
     notifications:
       enabled: false
   email_registrations:
-    enabled: true
+    enabled: false
 
 mailer:
   delivery_method: 'test'


### PR DESCRIPTION
Disable email signups for now due to excessive bot signups.
Fixes #3893 
